### PR TITLE
Potential fix for code scanning alert no. 30: Uncontrolled data used in path expression

### DIFF
--- a/deprecated/main.py
+++ b/deprecated/main.py
@@ -71,6 +71,7 @@ init_database()
 
 # Create directories
 os.makedirs("static/uploads", exist_ok=True)
+UPLOADS_DIR = os.path.abspath("static/uploads")
 os.makedirs("templates", exist_ok=True)
 
 # Discord bot setup
@@ -87,11 +88,19 @@ scheduler = AsyncIOScheduler()
 
 # Utility functions for error handling and image management
 async def cleanup_image(image_path: str) -> bool:
-    """Safely delete an image file"""
+    """Safely delete an image file if it's inside the uploads directory"""
     try:
-        if image_path and os.path.exists(image_path):
-            os.remove(image_path)
-            logger.info(f"Cleaned up image: {image_path}")
+        if not image_path:
+            return False
+        # Resolve the absolute, normalized path to the image within uploads dir
+        requested_path = os.path.abspath(os.path.normpath(os.path.join(UPLOADS_DIR, image_path)))
+        # Ensure the resulting path starts with the allowed upload directory
+        if not requested_path.startswith(UPLOADS_DIR + os.sep):
+            logger.warning(f"Attempt to delete a file outside upload dir: {requested_path}")
+            return False
+        if os.path.exists(requested_path):
+            os.remove(requested_path)
+            logger.info(f"Cleaned up image: {requested_path}")
             return True
     except Exception as e:
         logger.error(f"Failed to cleanup image {image_path}: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/pacnpal/polly/security/code-scanning/30](https://github.com/pacnpal/polly/security/code-scanning/30)

The vulnerability here is that an untrusted user can control the filesystem path (`image_path`) that gets deleted by the server via the `/htmx/remove-image` endpoint. To fix this, we should ensure that only valid files within a specific directory (such as `static/uploads/`) can be deleted, regardless of the user input. The best-practice fix is to resolve the user-provided filename (never an absolute or ".." path) within the allowed root directory, normalize it, and then check to ensure that the normalized path does not escape this root.

Here’s how to fix it:
1. Define (at the top of the file) a constant for the safe root directory, e.g., `UPLOADS_DIR = os.path.abspath("static/uploads")`.
2. In `cleanup_image`, normalize and resolve the `image_path` with respect to the upload directory.
3. Ensure the final normalized path starts with the upload directory; if not, refuse to delete.
4. Only delete the file if the checks pass.
5. Update all calls to `cleanup_image` (though, in this snippet, only the tainted usage in `/htmx/remove-image` is relevant).

You will need to import `os` if not present, and ensure the fix only touches the relevant places.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
