### PR TITLE
Potential fix for code scanning alert no. 29: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -6,6 +6,7 @@ Tests FastAPI routes, HTMX endpoints, and web functionality.
 import pytest
 from unittest.mock import Mock, patch
 from fastapi import status
+from urllib.parse import urlparse
 
 from polly.web_app import (
     create_app,
@@ -54,7 +55,8 @@ class TestCoreRoutes:
         ):
             response = web_client.get("/login", follow_redirects=False)
             assert response.status_code == status.HTTP_307_TEMPORARY_REDIRECT
-            assert "discord.com" in response.headers["location"]
+            location_host = urlparse(response.headers["location"]).hostname
+            assert location_host == "discord.com"
 
     def test_auth_callback_success(self, web_client):
         """Test successful OAuth callback."""


### PR DESCRIPTION
Potential fix for [https://github.com/pacnpal/polly/security/code-scanning/29](https://github.com/pacnpal/polly/security/code-scanning/29)

The best way to fix the problem is to parse the redirect URL using Python's `urllib.parse.urlparse`, then assert specifically on the host (netloc) and scheme, rather than checking for a substring.  

- Change the assertion on line 57 from checking if `"discord.com"` is a substring of the location header, to parsing the location URL and asserting that its hostname (or netloc) is equal to or ends with `discord.com`.
- Add an import for `urlparse` from Python's standard `urllib.parse` module if not already present.
- The edits are limited to the single test case assertion in `tests/test_web_app.py` line 57.
- No additional dependencies are required, as `urllib.parse` is part of the Python standard library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
