### PR TITLE
Potential fix for code scanning alert no. 33: Uncontrolled data used in path expression

### DIFF
--- a/polly/htmx_endpoints.py
+++ b/polly/htmx_endpoints.py
@@ -394,11 +394,24 @@ async def save_image_file(content: bytes, filename: str) -> str | None:
 
 
 async def cleanup_image(image_path: str) -> bool:
-    """Safely delete an image file"""
+    """Safely delete an image file; ensure path is within uploads dir"""
     try:
-        if image_path and isinstance(image_path, str) and os.path.exists(image_path):
-            os.remove(image_path)
-            logger.info(f"Cleaned up image: {image_path}")
+        if not image_path or not isinstance(image_path, str):
+            return False
+
+        # Enforce path within UPLOADS_DIR to prevent directory traversal or arbitrary file deletion
+        # Normalize and make paths absolute
+        abs_uploads_dir = UPLOADS_DIR
+        abs_image_path = os.path.abspath(os.path.normpath(image_path if os.path.isabs(image_path) else os.path.join(UPLOADS_DIR, image_path)))
+
+        # Only allow deletion if the file is within the uploads directory
+        if os.path.commonpath([abs_uploads_dir, abs_image_path]) != abs_uploads_dir:
+            logger.warning(f"Tried to remove file outside of uploads dir: {image_path}")
+            return False
+
+        if os.path.exists(abs_image_path):
+            os.remove(abs_image_path)
+            logger.info(f"Cleaned up image: {abs_image_path}")
             return True
     except Exception as e:
         logger.error(f"Failed to cleanup image {image_path}: {e}")

--- a/polly/htmx_endpoints.py
+++ b/polly/htmx_endpoints.py
@@ -377,10 +377,10 @@ async def save_image_file(content: bytes, filename: str) -> str | None:
     try:
         file_extension = filename.split(".")[-1].lower()
         unique_filename = f"{uuid.uuid4()}.{file_extension}"
-        image_path = f"static/uploads/{unique_filename}"
+        image_path = os.path.join(UPLOADS_DIR, unique_filename)
 
         # Ensure uploads directory exists
-        os.makedirs("static/uploads", exist_ok=True)
+        os.makedirs(UPLOADS_DIR, exist_ok=True)
 
         # Save file
         async with aiofiles.open(image_path, "wb") as f:


### PR DESCRIPTION
Potential fix for [https://github.com/pacnpal/polly/security/code-scanning/33](https://github.com/pacnpal/polly/security/code-scanning/33)

The best way to fix this issue is to ensure that only files within a designated uploads directory (e.g., `static/uploads/`) can be deleted by the `cleanup_image` function. To do this, normalize the received path, join it to a known base directory, then check that the normalized absolute path is still within the uploads directory. If not, abort the deletion.  
Specifically, before calling `os.remove(image_path)`, do the following:
- Set a constant for the trusted uploads directory (e.g., `UPLOADS_DIR = "static/uploads"`).
- Normalize the provided `image_path` using `os.path.normpath`, and combine it with the base directory if it's a relative filename (to handle cases like `myfile.png`).
- Convert both the final path and uploads directory to absolute paths.
- Use `os.path.commonpath` to ensure the file is within `UPLOADS_DIR`.
- Only call `os.remove` if this containment check passes.

All changes must only be in the already shown snippets, in `polly/htmx_endpoints.py` within `cleanup_image`. Add the constant and the check at an appropriate location in the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
