### PR TITLE
Potential fix for code scanning alert no. 28: Incomplete URL substring sanitization

### DIFF
--- a/tests/run_live_pentest.py
+++ b/tests/run_live_pentest.py
@@ -8,7 +8,7 @@ import sys
 import os
 import argparse
 from pathlib import Path
-
+from urllib.parse import urlparse
 # Add the project root to the Python path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
@@ -78,7 +78,7 @@ Examples:
     print("=" * 60)
 
     # Confirm authorization
-    if not args.url.startswith("https://polly.pacnp.al"):
+    if urlparse(args.url).hostname != "polly.pacnp.al":
         confirm = input("\nDo you have authorization to test this server? (yes/no): ")
         if confirm.lower() not in ["yes", "y"]:
             print("❌ Testing cancelled - authorization required")


### PR DESCRIPTION
Potential fix for [https://github.com/pacnpal/polly/security/code-scanning/28](https://github.com/pacnpal/polly/security/code-scanning/28)

To securely verify that the target URL points to the trusted live server, we should parse the URL and compare the hostname directly to the expected value, rather than using `startswith`. We will use Python's standard library (`urllib.parse`) to extract the hostname from `args.url`, then compare it to `"polly.pacnp.al"`. The fix should be applied in `main()` where the authorization check occurs (line 81). We need to import `urlparse` from `urllib.parse` at the top of the file (unless already imported), and replace the `startswith` check with a robust hostname comparison. No further code outside the shown snippet needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
