### PR TITLE
Potential fix for code scanning alert no. 1: Client-side cross-site scripting

### DIFF
--- a/templates/htmx/polls.html
+++ b/templates/htmx/polls.html
@@ -284,6 +284,11 @@
 <script>
 // Client-side poll filtering for better performance
 function filterPolls(filterType) {
+    // Defense-in-depth: restrict filterType to allowed list.
+    const allowedFilters = ['all', 'published', 'draft', 'archived'];
+    if (!allowedFilters.includes(filterType)) {
+        filterType = 'all';
+    }
     console.log('🔍 FILTER DEBUG - Filtering polls by:', filterType);
     
     // Update active tab
@@ -344,8 +349,12 @@ document.addEventListener('DOMContentLoaded', function() {
     console.log('🔍 FILTER DEBUG - Initializing client-side filtering');
     
     // Set initial filter based on URL or default to 'all'
+    const allowedFilters = ['all', 'published', 'draft', 'archived'];  // Add all the valid filter options here
     const urlParams = new URLSearchParams(window.location.search);
-    const initialFilter = urlParams.get('filter') || 'all';
+    let initialFilter = urlParams.get('filter') || 'all';
+    if (!allowedFilters.includes(initialFilter)) {
+        initialFilter = 'all';
+    }
     
     // Apply initial filter
     filterPolls(initialFilter);


### PR DESCRIPTION
Potential fix for [https://github.com/pacnpal/polly/security/code-scanning/1](https://github.com/pacnpal/polly/security/code-scanning/1)

To fix this DOM-based XSS, user-controlled values interpolated into HTML must be safely escaped or validated before being written to the page, especially in any data used with `innerHTML`.  

The best approach, without breaking current functionality, is to strictly control the set of valid filter types (i.e., enforce a whitelist, such as ["all", "published", "draft", ...]) and to escape/filter unexpected values to ensure they cannot be interpreted as HTML.  

Specifically:  
- Before passing `filterType` to any DOM-writing function, restrict it to an allowed set, and if it does not match, default to a safe value (e.g., "all").
- Alternatively or additionally, escape untrusted strings before inserting them as HTML (but whitelisting is preferable in this UI context since only known filter values are valid).
- Implement this in the `<script>` block in the same file, so everything is contained.

You will need to:  
- Add a whitelist array (e.g., `const allowedFilters = [...]`), and in code where `initialFilter` is set (lines 347–348), set it only if in the allowed set, otherwise default to "all".
- Optionally, perform this check again in `filterPolls` as a defense in depth.
- No external dependencies are needed.
- No changes to the rest of the HTML or logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
