### PR TITLE
Potential fix for code scanning alert no. 1: Client-side cross-site scripting

### DIFF
--- a/templates/htmx/polls.html
+++ b/templates/htmx/polls.html
@@ -282,6 +282,13 @@
 
 <!-- Client-side filtering JavaScript for efficiency -->
 <script>
+// Map internal filter keys to visible labels for safe rendering
+const filterLabels = {
+    all: "",
+    published: "Published",
+    draft: "Draft",
+    archived: "Archived"
+};
 // Client-side poll filtering for better performance
 function filterPolls(filterType) {
     // Defense-in-depth: restrict filterType to allowed list.
@@ -289,6 +296,8 @@ function filterPolls(filterType) {
     if (!allowedFilters.includes(filterType)) {
         filterType = 'all';
     }
+    // Get display label, fallback to safe empty string
+    const filterLabel = filterLabels[filterType] || "";
     console.log('🔍 FILTER DEBUG - Filtering polls by:', filterType);
     
     // Update active tab
@@ -330,11 +339,11 @@ function filterPolls(filterType) {
         emptyDiv.className = 'col-12 text-center no-polls-message';
         emptyDiv.innerHTML = `
             <i class="fas fa-inbox fa-3x text-muted mb-3"></i>
-            <h5 class="text-muted">No ${filterType === 'all' ? '' : filterType} polls found</h5>
+            <h5 class="text-muted">No ${filterType === 'all' ? '' : filterLabel} polls found</h5>
             <p class="text-muted">
                 ${filterType === 'all' 
                     ? 'Create your first poll to get started!' 
-                    : `You don't have any ${filterType} polls yet.`}
+                    : `You don't have any ${filterLabel.toLowerCase()} polls yet.`}
             </p>
         `;
         container.appendChild(emptyDiv);


### PR DESCRIPTION
Potential fix for [https://github.com/pacnpal/polly/security/code-scanning/1](https://github.com/pacnpal/polly/security/code-scanning/1)

To address this DOM-XSS vulnerability, we should ensure that only explicitly allowed filter values ever reach the DOM update, **never trusting user input directly**. This means:
- In `filterPolls(filterType)`, verify and enforce that `filterType` is a string from the allowed list before updating DOM.
- Before rendering any string in template literals via `.innerHTML`, ensure all interpolated values are known-safe.
- The fix: strictly enforce the allowlist by introducing a canonical mapping (`filterLabels`) that maps internal filter keys to user-facing labels, and always use this mapping when producing output for the DOM (never raw filter values).  
- In particular, instead of outputting `${filterType}` or `${filterType === 'all' ? '' : filterType}` in the template literal, use the mapping to render a human-readable label.
- Changes are confined to the `<script>` block in `templates/htmx/polls.html`, lines 284–380.  
- This fix is sufficient and minimizes code changes:  
  1. Add a filter label mapping at the top of the `<script>` block (`const filterLabels = ...`).  
  2. Replace usages of `${filterType}` and similar template literals in the empty state HTML with the mapped label, never the raw string.

No external libraries are required; only standard, in-place JavaScript fixes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
