### PR TITLE
Potential fix for code scanning alert no. 40: Information exposure through an exception

### DIFF
--- a/polly/super_admin_endpoints_enhanced.py
+++ b/polly/super_admin_endpoints_enhanced.py
@@ -662,7 +662,7 @@ async def reopen_poll_api(
     except Exception as e:
         logger.error(f"Unexpected error in enhanced reopen_poll_api for poll {poll_id}: {e}")
         return JSONResponse(
-            content={"success": False, "error": f"Unexpected error during poll reopen: {str(e)}"},
+            content={"success": False, "error": "An internal error occurred while trying to reopen the poll."},
             status_code=500
         )
 


### PR DESCRIPTION
Potential fix for [https://github.com/pacnpal/polly/security/code-scanning/40](https://github.com/pacnpal/polly/security/code-scanning/40)

To fix the problem, replace the exposed exception message in the API response with a generic error string that does not reveal internal information. In detail, change the construction of the JSON error response in line 665 within the `except Exception as e` block of the `reopen_poll_api` function. Instead of interpolating `str(e)`, use a standardized message like `"An internal error occurred while trying to reopen the poll."`. Additionally, full details (with stack trace) should be logged server-side for diagnostic purposes—which is already being done via `logger.error`. No changes are needed to the logging code. All changes are confined to the response construction.

**Required changes:**
- In `polly/super_admin_endpoints_enhanced.py`, edit the error response in line 665 (and line 664, for context) so that it does not interpolate `str(e)`, and instead returns a generic error message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
