### PR TITLE
Potential fix for code scanning alert no. 39: Information exposure through an exception

### DIFF
--- a/polly/services/poll/poll_reopen_service.py
+++ b/polly/services/poll/poll_reopen_service.py
@@ -98,8 +98,8 @@ class PollReopeningService:
                     return {"success": False, "error": "Poll has no channel ID"}
                 
             except Exception as e:
-                logger.error(f"❌ UNIFIED REOPEN {poll_id} - Error fetching poll data: {e}")
-                return {"success": False, "error": f"Database error: {str(e)}"}
+                logger.error(f"❌ UNIFIED REOPEN {poll_id} - Error fetching poll data: {e}", exc_info=True)
+                return {"success": False, "error": "A database error occurred while fetching poll data."}
             finally:
                 db.close()
 
@@ -113,8 +113,8 @@ class PollReopeningService:
                     logger.info(f"✅ UNIFIED REOPEN {poll_id} - Deleted {votes_deleted} votes")
                 except Exception as e:
                     db.rollback()
-                    logger.error(f"❌ UNIFIED REOPEN {poll_id} - Error resetting votes: {e}")
-                    return {"success": False, "error": f"Failed to reset votes: {str(e)}"}
+                    logger.error(f"❌ UNIFIED REOPEN {poll_id} - Error resetting votes: {e}", exc_info=True)
+                    return {"success": False, "error": "Failed to reset votes due to internal error."}
                 finally:
                     db.close()
 


### PR DESCRIPTION
Potential fix for [https://github.com/pacnpal/polly/security/code-scanning/39](https://github.com/pacnpal/polly/security/code-scanning/39)

To fix this problem:
- **In the `reopen_poll_unified` method in `poll_reopen_service.py`**, replace error dictionaries that include the raw message from exceptions (like `str(e)`) with sanitized, generic error messages (e.g., `"A database error occurred."`). Continue to log the detailed exception server-side for debugging and support, but avoid passing the details on to the client.
- Make this change for all such places: e.g., "Database error: " + sanitized message instead of "Database error: {str(e)}".
- Ensure logging calls continue to include `e` so that information is not lost on the server side.
- No additional dependencies are needed for this fix.
- Only code in `polly/services/poll/poll_reopen_service.py` is edited; `polly/super_admin_endpoints_enhanced.py` does not require changes since it correctly relays the result of the called service.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
