### PR TITLE
Add Pydantic v2 request models for poll create/update/vote

### DIFF
--- a/polly/bulletproof_operations.py
+++ b/polly/bulletproof_operations.py
@@ -616,9 +616,13 @@ class BulletproofPollOperations:
                             "error": f"Poll is not active (status: {str(getattr(poll, 'status', ''))})",
                         }
 
-                    # Step 1b: Validate vote data using existing validator
+                    # Step 1b: Validate vote data using existing validator,
+                    # adopting the normalized (user_id, option_index) so any
+                    # whitespace stripping persists into the recorded Vote row.
                     try:
-                        VoteValidator.validate_vote_data(poll, user_id, option_index)
+                        user_id, option_index = VoteValidator.validate_vote_data(
+                            poll, user_id, option_index
+                        )
                     except Exception as e:
                         db.rollback()
                         logger.error(f"Vote data validation failed: {e}")

--- a/polly/htmx_endpoints.py
+++ b/polly/htmx_endpoints.py
@@ -3351,27 +3351,7 @@ def validate_poll_form_data(form_data, current_user_id: str) -> tuple[bool, list
     except PydanticValidationError as exc:
         return False, validation_error_to_messages(exc), {}
 
-    validated_data = {
-        "name": model.name,
-        "question": model.question,
-        "server_id": model.server_id,
-        "channel_id": model.channel_id,
-        "options": model.options,
-        "open_time": model.open_time_utc,
-        "close_time": model.close_time_utc,
-        "timezone": model.timezone,
-        "anonymous": model.anonymous,
-        "multiple_choice": model.multiple_choice,
-        "max_choices": model.max_choices,
-        "open_immediately": model.open_immediately,
-        "ping_role_enabled": model.ping_role_enabled,
-        "ping_role_id": model.ping_role_id,
-        "ping_role_on_close": model.ping_role_on_close,
-        "ping_role_on_update": model.ping_role_on_update,
-        "image_message_text": model.image_message_text,
-        "creator_id": current_user_id,
-    }
-    return True, [], validated_data
+    return True, [], model.to_validated_data_dict(current_user_id)
 
 
 async def create_poll_htmx(
@@ -5077,6 +5057,20 @@ async def update_poll_htmx(
             return templates.TemplateResponse(
                 "htmx/components/inline_error.html",
                 {"request": request, "message": "At least 2 options required"},
+            )
+
+        # The "Open Immediately" toggle isn't a valid edit operation:
+        # PollFormRequest sets open_time_utc to now(UTC), which fails the
+        # next-minute scheduling check below, and the editor lacks the
+        # immediate-open dispatch the create flow uses. Direct users to
+        # the dedicated "Open Now" button instead.
+        if validated_data.get("open_immediately"):
+            return templates.TemplateResponse(
+                "htmx/components/inline_error.html",
+                {
+                    "request": request,
+                    "message": "Use the 'Open Now' button to open this poll immediately; the edit form only supports scheduling.",
+                },
             )
 
         # Use the validated times from the validation function

--- a/polly/htmx_endpoints.py
+++ b/polly/htmx_endpoints.py
@@ -14,6 +14,7 @@ import os
 UPLOADS_DIR = os.path.abspath("static/uploads")
 
 from fastapi import Request, Depends
+from pydantic import ValidationError as PydanticValidationError
 
 # Ensure UPLOADS_DIR is ALWAYS absolute and normalized
 UPLOADS_DIR = os.path.abspath(os.path.normpath("static/uploads"))
@@ -39,6 +40,11 @@ try:
     from .json_import import PollJSONImporter, PollJSONExporter
     from .debug_config import get_debug_logger
     from .data_utils import sanitize_data_for_json
+    from .poll_request_models import (
+        PollFormRequest,
+        poll_form_to_dict,
+        validation_error_to_messages,
+    )
 except ImportError:
     from auth import require_auth, DiscordUser  # type: ignore
     from database import (  # type: ignore
@@ -58,6 +64,11 @@ except ImportError:
     from json_import import PollJSONImporter, PollJSONExporter  # type: ignore
     from debug_config import get_debug_logger  # type: ignore
     from data_utils import sanitize_data_for_json  # type: ignore
+    from poll_request_models import (  # type: ignore
+        PollFormRequest,
+        poll_form_to_dict,
+        validation_error_to_messages,
+    )
 
 logger = get_debug_logger(__name__)
 
@@ -3338,306 +3349,39 @@ async def get_guild_emojis_htmx(
 
 
 def validate_poll_form_data(form_data, current_user_id: str) -> tuple[bool, list, dict]:
-    """Validate poll form data and return validation results"""
-    validation_errors = []
-    validated_data = {}
+    """Validate poll form data via the :class:`PollFormRequest` Pydantic model.
 
-    # Extract open_immediately flag FIRST - this affects time validation logic
-    open_immediately = form_data.get("open_immediately") == "true"
+    Kept as a thin wrapper so existing callers continue to receive the
+    ``(is_valid, errors, validated_data_dict)`` tuple. New code should use
+    :class:`PollFormRequest.model_validate` directly.
+    """
+    raw = poll_form_to_dict(form_data)
+    try:
+        model = PollFormRequest.model_validate(raw)
+    except PydanticValidationError as exc:
+        return False, validation_error_to_messages(exc), {}
 
-    # Extract form data
-    name = safe_get_form_data(form_data, "name")
-    question = safe_get_form_data(form_data, "question")
-    server_id = safe_get_form_data(form_data, "server_id")
-    channel_id = safe_get_form_data(form_data, "channel_id")
-    open_time = safe_get_form_data(form_data, "open_time")
-    close_time = safe_get_form_data(form_data, "close_time")
-    timezone_str = safe_get_form_data(form_data, "timezone", "US/Eastern")
-
-    # Validate poll name
-    if not name or len(name.strip()) < 3:
-        validation_errors.append(
-            {
-                "field_name": "Poll Name",
-                "message": "Must be at least 3 characters long",
-                "suggestion": "Try something descriptive like 'Weekend Movie Night' or 'Team Lunch Choice'",
-            }
-        )
-    elif len(name.strip()) > 255:
-        validation_errors.append(
-            {
-                "field_name": "Poll Name",
-                "message": "Must be less than 255 characters",
-                "suggestion": "Try shortening your poll name to be more concise",
-            }
-        )
-    else:
-        validated_data["name"] = name.strip()
-
-    # Validate question
-    if not question or len(question.strip()) < 5:
-        validation_errors.append(
-            {
-                "field_name": "Question",
-                "message": "Must be at least 5 characters long",
-                "suggestion": "Be specific! Instead of 'Pick one', try 'Which movie should we watch this Friday?'",
-            }
-        )
-    elif len(question.strip()) > 2000:
-        validation_errors.append(
-            {
-                "field_name": "Question",
-                "message": "Must be less than 2000 characters",
-                "suggestion": "Try to keep your question concise and to the point",
-            }
-        )
-    else:
-        validated_data["question"] = question.strip()
-
-    # Validate server selection
-    if not server_id:
-        validation_errors.append(
-            {
-                "field_name": "Server",
-                "message": "Please select a Discord server",
-                "suggestion": "Choose the server where you want to post this poll",
-            }
-        )
-    else:
-        validated_data["server_id"] = server_id
-
-    # Validate channel selection
-    if not channel_id:
-        validation_errors.append(
-            {
-                "field_name": "Channel",
-                "message": "Please select a Discord channel",
-                "suggestion": "Choose the channel where you want to post this poll",
-            }
-        )
-    else:
-        validated_data["channel_id"] = channel_id
-
-    # Validate options
-    options = []
-    for i in range(1, 11):
-        option = form_data.get(f"option{i}")
-        if option:
-            option_text = str(option).strip()
-            if option_text:
-                options.append(option_text)
-
-    if len(options) < 2:
-        validation_errors.append(
-            {
-                "field_name": "Poll Options",
-                "message": "At least 2 options are required",
-                "suggestion": "Add more choices for people to vote on. Great polls usually have 3-5 options!",
-            }
-        )
-    elif len(options) > 10:
-        validation_errors.append(
-            {
-                "field_name": "Poll Options",
-                "message": "Maximum 10 options allowed",
-                "suggestion": "Try to keep your options focused. Too many choices can be overwhelming!",
-            }
-        )
-    else:
-        validated_data["options"] = options
-
-    # Validate times - skip open_time validation if opening immediately
-    if not open_immediately and not open_time:
-        validation_errors.append(
-            {
-                "field_name": "Open Time",
-                "message": "Please select when the poll should start",
-                "suggestion": "Choose a time when your audience will be active",
-            }
-        )
-    elif not close_time:
-        validation_errors.append(
-            {
-                "field_name": "Close Time",
-                "message": "Please select when the poll should end",
-                "suggestion": "Give people enough time to vote, but not too long that they forget",
-            }
-        )
-    else:
-        try:
-            # Parse times with timezone - handle immediate vs scheduled polls
-            if open_immediately:
-                # For immediate polls, set open_time to current time and only validate close_time
-                now = datetime.now(pytz.UTC)
-                open_dt = now
-                close_dt = safe_parse_datetime_with_timezone(close_time, timezone_str)
-
-                # Validate close time is in the future
-                if close_dt <= now:
-                    user_tz = pytz.timezone(
-                        validate_and_normalize_timezone(timezone_str)
-                    )
-                    next_minute_local = (now + timedelta(minutes=1)).astimezone(user_tz)
-                    suggested_time = next_minute_local.strftime("%I:%M %p")
-                    validation_errors.append(
-                        {
-                            "field_name": "Close Time",
-                            "message": "Must be in the future for immediate polls",
-                            "suggestion": f"Try {suggested_time} or later",
-                        }
-                    )
-                else:
-                    # Check minimum duration (1 minute)
-                    duration = close_dt - open_dt
-                    if duration < timedelta(minutes=1):
-                        validation_errors.append(
-                            {
-                                "field_name": "Poll Duration",
-                                "message": "Poll must run for at least 1 minute",
-                                "suggestion": "Give people time to see and respond to your poll",
-                            }
-                        )
-                    elif duration > timedelta(days=30):
-                        validation_errors.append(
-                            {
-                                "field_name": "Poll Duration",
-                                "message": "Poll cannot run for more than 30 days",
-                                "suggestion": "Try a shorter duration to keep engagement high",
-                            }
-                        )
-                    else:
-                        validated_data["open_time"] = open_dt
-                        validated_data["close_time"] = close_dt
-            else:
-                # For scheduled polls, validate both times normally
-                open_dt = safe_parse_datetime_with_timezone(open_time, timezone_str)
-                close_dt = safe_parse_datetime_with_timezone(close_time, timezone_str)
-
-                # Validate times using the poll's timezone
-                now = datetime.now(pytz.UTC)
-                
-                # Get the user's timezone for proper validation
-                user_tz = pytz.timezone(validate_and_normalize_timezone(timezone_str))
-                now_in_user_tz = now.astimezone(user_tz)
-                
-                # Calculate next full minute in user's timezone, then convert to UTC for comparison
-                next_minute_user_tz = now_in_user_tz.replace(second=0, microsecond=0) + timedelta(minutes=1)
-                next_minute_utc = next_minute_user_tz.astimezone(pytz.UTC)
-
-                if open_dt < next_minute_utc:
-                    suggested_time = next_minute_user_tz.strftime("%I:%M %p")
-                    validation_errors.append(
-                        {
-                            "field_name": "Open Time",
-                            "message": "Must be scheduled for at least the next full minute",
-                            "suggestion": f"Try {suggested_time} or later in your timezone ({timezone_str})",
-                        }
-                    )
-                elif close_dt <= open_dt:
-                    validation_errors.append(
-                        {
-                            "field_name": "Close Time",
-                            "message": "Must be after the open time",
-                            "suggestion": "Make sure your poll runs for at least a few minutes so people can vote",
-                        }
-                    )
-                else:
-                    # Check minimum duration (1 minute)
-                    duration = close_dt - open_dt
-                    if duration < timedelta(minutes=1):
-                        validation_errors.append(
-                            {
-                                "field_name": "Poll Duration",
-                                "message": "Poll must run for at least 1 minute",
-                                "suggestion": "Give people time to see and respond to your poll",
-                            }
-                        )
-                    elif duration > timedelta(days=30):
-                        validation_errors.append(
-                            {
-                                "field_name": "Poll Duration",
-                                "message": "Poll cannot run for more than 30 days",
-                                "suggestion": "Try a shorter duration to keep engagement high",
-                            }
-                        )
-                    else:
-                        validated_data["open_time"] = open_dt
-                        validated_data["close_time"] = close_dt
-        except Exception:
-            validation_errors.append(
-                {
-                    "field_name": "Poll Times",
-                    "message": "Invalid date/time format",
-                    "suggestion": "Please check your date and time selections",
-                }
-            )
-
-    # Handle role ping fields
-    ping_role_enabled = form_data.get("ping_role_enabled") == "true"
-    ping_role_id = safe_get_form_data(form_data, "ping_role_id", "")
-    ping_role_on_close = form_data.get("ping_role_on_close") == "true"
-    ping_role_on_update = form_data.get("ping_role_on_update") == "true"
-
-    # Validate role ping settings
-    if ping_role_enabled and not ping_role_id:
-        validation_errors.append(
-            {
-                "field_name": "Role Selection",
-                "message": "Please select a role to ping when role ping is enabled",
-                "suggestion": "Choose a role from the dropdown or disable role ping",
-            }
-        )
-
-    validated_data["ping_role_enabled"] = ping_role_enabled
-    validated_data["ping_role_id"] = ping_role_id if ping_role_enabled else None
-    validated_data["ping_role_on_close"] = (
-        ping_role_on_close if ping_role_enabled else False
-    )
-    validated_data["ping_role_on_update"] = (
-        ping_role_on_update if ping_role_enabled else False
-    )
-
-    # Add other validated data
-    validated_data["timezone"] = validate_and_normalize_timezone(timezone_str)
-    validated_data["anonymous"] = form_data.get("anonymous") == "true"
-    validated_data["multiple_choice"] = form_data.get("multiple_choice") == "true"
-    
-    # Handle max_choices for multiple choice polls
-    max_choices_str = safe_get_form_data(form_data, "max_choices", "")
-    max_choices = None
-    if validated_data["multiple_choice"] and max_choices_str:
-        try:
-            max_choices = int(max_choices_str)
-            # Validate max_choices is reasonable (between 2 and 10)
-            if max_choices < 2 or max_choices > 10:
-                validation_errors.append(
-                    {
-                        "field_name": "Maximum Choices",
-                        "message": "Must be between 2 and 10 choices",
-                        "suggestion": "Choose a reasonable number of choices users can select",
-                    }
-                )
-            else:
-                validated_data["max_choices"] = max_choices
-        except ValueError:
-            validation_errors.append(
-                {
-                    "field_name": "Maximum Choices",
-                    "message": "Invalid number format",
-                    "suggestion": "Please select a valid number of choices",
-                }
-            )
-    else:
-        validated_data["max_choices"] = max_choices
-    
-    validated_data["creator_id"] = current_user_id
-    validated_data["image_message_text"] = safe_get_form_data(
-        form_data, "image_message_text", ""
-    )
-    validated_data["open_immediately"] = open_immediately
-
-    is_valid = len(validation_errors) == 0
-    return is_valid, validation_errors, validated_data
+    validated_data = {
+        "name": model.name,
+        "question": model.question,
+        "server_id": model.server_id,
+        "channel_id": model.channel_id,
+        "options": model.options,
+        "open_time": model.open_time_utc,
+        "close_time": model.close_time_utc,
+        "timezone": model.timezone,
+        "anonymous": model.anonymous,
+        "multiple_choice": model.multiple_choice,
+        "max_choices": model.max_choices,
+        "open_immediately": model.open_immediately,
+        "ping_role_enabled": model.ping_role_enabled,
+        "ping_role_id": model.ping_role_id,
+        "ping_role_on_close": model.ping_role_on_close,
+        "ping_role_on_update": model.ping_role_on_update,
+        "image_message_text": model.image_message_text,
+        "creator_id": current_user_id,
+    }
+    return True, [], validated_data
 
 
 async def create_poll_htmx(

--- a/polly/htmx_endpoints.py
+++ b/polly/htmx_endpoints.py
@@ -41,6 +41,8 @@ try:
     from .debug_config import get_debug_logger
     from .data_utils import sanitize_data_for_json
     from .poll_request_models import (
+        DEFAULT_TIMEZONE,
+        TIMEZONE_ALIASES,
         PollFormRequest,
         poll_form_to_dict,
         validation_error_to_messages,
@@ -65,6 +67,8 @@ except ImportError:
     from debug_config import get_debug_logger  # type: ignore
     from data_utils import sanitize_data_for_json  # type: ignore
     from poll_request_models import (  # type: ignore
+        DEFAULT_TIMEZONE,
+        TIMEZONE_ALIASES,
         PollFormRequest,
         poll_form_to_dict,
         validation_error_to_messages,
@@ -260,40 +264,26 @@ def validate_emoji(emoji_text: str) -> tuple[bool, str]:
 
 
 def validate_and_normalize_timezone(timezone_str: str) -> str:
-    """Validate and normalize timezone string, handling EDT/EST issues"""
+    """Validate and normalize timezone string, handling EDT/EST issues.
+
+    Unlike :func:`poll_request_models._normalize_timezone` (which raises on
+    invalid input), this helper preserves the long-standing graceful-default
+    behavior for general-purpose callers.
+    """
     if not timezone_str:
-        return "US/Eastern"  # Default to Eastern instead of UTC
+        return DEFAULT_TIMEZONE
 
-    # Handle common timezone aliases and server timezone issues
-    timezone_mapping = {
-        "EDT": "US/Eastern",
-        "EST": "US/Eastern",
-        "CDT": "US/Central",
-        "CST": "US/Central",
-        "MDT": "US/Mountain",
-        "MST": "US/Mountain",
-        "PDT": "US/Pacific",
-        "PST": "US/Pacific",
-        "Eastern": "US/Eastern",
-        "Central": "US/Central",
-        "Mountain": "US/Mountain",
-        "Pacific": "US/Pacific",
-    }
+    timezone_str = TIMEZONE_ALIASES.get(timezone_str, timezone_str)
 
-    # Check if it's a mapped timezone
-    if timezone_str in timezone_mapping:
-        timezone_str = timezone_mapping[timezone_str]
-
-    # Validate the timezone
     try:
         pytz.timezone(timezone_str)
         return timezone_str
     except pytz.UnknownTimeZoneError:
-        logger.warning(f"Unknown timezone '{timezone_str}', defaulting to US/Eastern")
-        return "US/Eastern"  # Default to Eastern instead of UTC
+        logger.warning(f"Unknown timezone '{timezone_str}', defaulting to {DEFAULT_TIMEZONE}")
+        return DEFAULT_TIMEZONE
     except Exception as e:
         logger.error(f"Error validating timezone '{timezone_str}': {e}")
-        return "US/Eastern"  # Default to Eastern instead of UTC
+        return DEFAULT_TIMEZONE
 
 
 def safe_parse_datetime_with_timezone(datetime_str: str, timezone_str: str) -> datetime:

--- a/polly/htmx_endpoints.py
+++ b/polly/htmx_endpoints.py
@@ -5044,13 +5044,10 @@ async def update_poll_htmx(
         # Use unified emoji processor for consistent handling
         unified_processor = get_unified_emoji_processor(bot)
 
-        # Get options from form data
-        options = []
-        for i in range(1, 11):
-            option = form_data.get(f"option{i}")
-            if option:
-                option_text = str(option).strip()
-                options.append(option_text)
+        # Use the canonical option list from PollFormRequest so quote/empty
+        # stripping done by the model is preserved here. Re-deriving from
+        # form_data would diverge and risk option/emoji index mismatches.
+        options = list(validated_data["options"])
 
         # Extract emoji inputs from form data
         emoji_inputs = unified_processor.extract_emoji_inputs_from_form(

--- a/polly/poll_operations.py
+++ b/polly/poll_operations.py
@@ -490,9 +490,13 @@ class BulletproofPollOperations:
                             "error": f"Poll is not active (status: {TypeSafeColumn.get_string(poll, 'status')})",
                         }
 
-                    # Step 1b: Validate vote data using existing validator
+                    # Step 1b: Validate vote data using existing validator,
+                    # adopting the normalized (user_id, option_index) so any
+                    # whitespace stripping persists into the recorded Vote row.
                     try:
-                        VoteValidator.validate_vote_data(poll, user_id, option_index)
+                        user_id, option_index = VoteValidator.validate_vote_data(
+                            poll, user_id, option_index
+                        )
                     except Exception as e:
                         db.rollback()
                         return {"success": False, "error": str(e)}

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -179,20 +179,13 @@ class PollFormRequest(BaseModel):
             return None
         return value
 
-    @field_validator("ping_role_id")
-    @classmethod
-    def _ping_role_id_must_be_numeric(cls, value: Optional[str]) -> Optional[str]:
-        if value is None:
-            return None
-        if not value.isdigit():
-            raise ValueError("Role Selection: must be a numeric Discord ID")
-        return value
-
     @model_validator(mode="after")
     def _resolve_dependent_fields(self) -> "PollFormRequest":
         self.max_choices = self._resolve_max_choices()
 
         if not self.ping_role_enabled:
+            # Role ping disabled: ignore any stale/tampered ping_role_id
+            # rather than rejecting the form, matching legacy behavior.
             self.ping_role_id = None
             self.ping_role_on_close = False
             self.ping_role_on_update = False
@@ -200,6 +193,8 @@ class PollFormRequest(BaseModel):
             raise ValueError(
                 "Role Selection: please select a role to ping when role ping is enabled"
             )
+        elif not self.ping_role_id.isdigit():
+            raise ValueError("Role Selection: must be a numeric Discord ID")
 
         open_dt, close_dt = self._parse_times()
         self._validate_time_window(open_dt, close_dt)
@@ -268,6 +263,13 @@ class PollFormRequest(BaseModel):
                     f"Poll Times: {value} does not exist in {tz} (DST gap); "
                     "pick a time outside the transition"
                 ) from exc
+        else:
+            # Mirror legacy ``safe_parse_datetime_with_timezone``: if an
+            # aware datetime ever reaches us (e.g. via a non-form caller),
+            # re-anchor it into the user-selected zone first. Mathematically
+            # equivalent to going straight to UTC, but keeps the chosen tz
+            # as the visible source of truth.
+            dt = dt.astimezone(tz)
         return dt.astimezone(pytz.UTC)
 
     def _validate_time_window(

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -324,6 +324,35 @@ class PollFormRequest(BaseModel):
                 "Poll Duration: poll cannot run for more than 30 days"
             )
 
+    def to_validated_data_dict(self, creator_id: str) -> dict:
+        """Return the legacy ``(field -> value)`` dict shape used by the
+        HTMX endpoints. Centralizing it here keeps the model the single
+        source of truth: any new field added to the model only needs to
+        be added once for downstream callers to pick it up.
+        ``open_time`` / ``close_time`` use the computed UTC datetimes so
+        callers can drop straight into APScheduler.
+        """
+        return {
+            "name": self.name,
+            "question": self.question,
+            "server_id": self.server_id,
+            "channel_id": self.channel_id,
+            "options": self.options,
+            "open_time": self.open_time_utc,
+            "close_time": self.close_time_utc,
+            "timezone": self.timezone,
+            "anonymous": self.anonymous,
+            "multiple_choice": self.multiple_choice,
+            "max_choices": self.max_choices,
+            "open_immediately": self.open_immediately,
+            "ping_role_enabled": self.ping_role_enabled,
+            "ping_role_id": self.ping_role_id,
+            "ping_role_on_close": self.ping_role_on_close,
+            "ping_role_on_update": self.ping_role_on_update,
+            "image_message_text": self.image_message_text,
+            "creator_id": creator_id,
+        }
+
 
 PollCreateRequest = PollFormRequest
 PollUpdateRequest = PollFormRequest

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -143,7 +143,15 @@ class PollFormRequest(BaseModel):
     @field_validator("timezone", mode="before")
     @classmethod
     def _coerce_timezone(cls, value: Any) -> str:
-        return _normalize_timezone(value if isinstance(value, str) else None)
+        # ``None``/empty defaults to DEFAULT_TIMEZONE; anything provided but
+        # not a string (list, int, …) is treated as tampered input and
+        # rejected, matching ``_normalize_timezone``'s posture for invalid
+        # explicit values.
+        if value is None:
+            return _normalize_timezone(None)
+        if not isinstance(value, str):
+            raise ValueError(f"Timezone: invalid timezone ({value!r})")
+        return _normalize_timezone(value)
 
     @field_validator("options", mode="before")
     @classmethod
@@ -467,14 +475,11 @@ def validation_error_to_messages(exc: ValidationError) -> List[dict]:
             detail_after_prefix = tail.strip() or msg
 
         if raw_field in _FIELD_LABELS:
-            # Concrete loc: trust the canonical label and drop the redundant
-            # prefix from the message body when it matches.
+            # Concrete loc: trust the canonical label and drop any redundant
+            # "Label: ..." prefix from the message body so we don't render
+            # output like "Poll Options: Options: duplicates not allowed".
             field_name = _FIELD_LABELS[raw_field]
-            detail = (
-                detail_after_prefix
-                if prefix_label and prefix_label == field_name
-                else msg
-            )
+            detail = detail_after_prefix if prefix_label else msg
         elif prefix_label:
             # No useful loc; fall back to the message-level prefix and
             # rehydrate raw_field via _LABEL_TO_FIELD for suggestion lookup.

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -10,6 +10,7 @@ calls. Use :func:`parse_poll_form_request` as a FastAPI dependency
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timedelta
 from typing import Any, List, Optional, Tuple
 
@@ -23,13 +24,6 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-
-try:
-    from .debug_config import get_debug_logger
-except ImportError:  # pragma: no cover - script-mode imports
-    from debug_config import get_debug_logger  # type: ignore
-
-logger = get_debug_logger(__name__)
 
 
 _TIMEZONE_ALIASES = {
@@ -88,8 +82,8 @@ class PollFormRequest(BaseModel):
 
     name: str = Field(..., min_length=3, max_length=255)
     question: str = Field(..., min_length=5, max_length=2000)
-    server_id: str = Field(..., min_length=1)
-    channel_id: str = Field(..., min_length=1)
+    server_id: str = Field(..., min_length=1, pattern=r"^\d+$")
+    channel_id: str = Field(..., min_length=1, pattern=r"^\d+$")
     options: List[str] = Field(..., min_length=2, max_length=10)
 
     timezone: str = Field(default="US/Eastern")
@@ -99,7 +93,10 @@ class PollFormRequest(BaseModel):
     open_immediately: bool = False
     anonymous: bool = False
     multiple_choice: bool = False
-    max_choices: Optional[int] = Field(default=None, ge=2, le=10)
+    # Carried as Optional[Any] so we can defer numeric coercion / range checks
+    # to ``_resolve_dependent_fields``: a value of ``"1"`` on a single-choice
+    # poll must be discarded, not rejected.
+    max_choices: Optional[Any] = None
 
     ping_role_enabled: bool = False
     ping_role_id: Optional[str] = None
@@ -122,7 +119,27 @@ class PollFormRequest(BaseModel):
         if value is None:
             return []
         if isinstance(value, list):
-            return [str(item).strip() for item in value if str(item).strip()]
+            cleaned = []
+            for item in value:
+                text = str(item).strip()
+                if not text:
+                    continue
+                # Match legacy PollValidator.validate_poll_options: drop
+                # bare quotes while keeping Discord <:emoji:id> markers intact.
+                cleaned.append(re.sub(r'["\']', "", text))
+            return cleaned
+        return value
+
+    @field_validator("options")
+    @classmethod
+    def _validate_option_items(cls, value: List[str]) -> List[str]:
+        for index, option in enumerate(value, start=1):
+            if len(option) > 100:
+                raise ValueError(
+                    f"Option {index}: must be 100 characters or fewer"
+                )
+        if len(set(value)) != len(value):
+            raise ValueError("Options: duplicate options are not allowed")
         return value
 
     @field_validator("ping_role_id", mode="before")
@@ -134,10 +151,18 @@ class PollFormRequest(BaseModel):
             return None
         return value
 
+    @field_validator("ping_role_id")
+    @classmethod
+    def _ping_role_id_must_be_numeric(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if not value.isdigit():
+            raise ValueError("Role Id: must be a numeric Discord ID")
+        return value
+
     @model_validator(mode="after")
     def _resolve_dependent_fields(self) -> "PollFormRequest":
-        if not self.multiple_choice:
-            self.max_choices = None
+        self.max_choices = self._resolve_max_choices()
 
         if not self.ping_role_enabled:
             self.ping_role_id = None
@@ -153,6 +178,27 @@ class PollFormRequest(BaseModel):
         self.open_time_utc = open_dt
         self.close_time_utc = close_dt
         return self
+
+    def _resolve_max_choices(self) -> Optional[int]:
+        if not self.multiple_choice:
+            return None
+        if self.max_choices is None or self.max_choices == "":
+            return None
+        try:
+            parsed = int(self.max_choices)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "Maximum Choices: must be a valid number"
+            ) from exc
+        if parsed < 2:
+            raise ValueError("Maximum Choices: must be at least 2")
+        if parsed > 10:
+            raise ValueError("Maximum Choices: cannot exceed 10")
+        if parsed > len(self.options):
+            raise ValueError(
+                f"Maximum Choices: cannot exceed the number of options ({len(self.options)})"
+            )
+        return parsed
 
     def _parse_times(self) -> Tuple[datetime, datetime]:
         if not self.close_time:

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -105,8 +105,11 @@ class PollFormRequest(BaseModel):
 
     image_message_text: str = ""
 
-    open_time_utc: Optional[datetime] = None
-    close_time_utc: Optional[datetime] = None
+    # Internal scratch fields populated by ``_resolve_dependent_fields``;
+    # excluded from schemas and ``model_dump()`` since they aren't part of
+    # the request payload.
+    open_time_utc: Optional[datetime] = Field(default=None, exclude=True)
+    close_time_utc: Optional[datetime] = Field(default=None, exclude=True)
 
     @field_validator("timezone", mode="before")
     @classmethod
@@ -326,24 +329,76 @@ def poll_form_to_dict(form_data: Any) -> dict:
     }
 
 
+_FIELD_LABELS = {
+    "name": "Poll Name",
+    "question": "Question",
+    "server_id": "Server",
+    "channel_id": "Channel",
+    "options": "Poll Options",
+    "open_time": "Open Time",
+    "close_time": "Close Time",
+    "max_choices": "Maximum Choices",
+    "ping_role_id": "Role Selection",
+    "timezone": "Timezone",
+}
+
+_FIELD_SUGGESTIONS = {
+    "name": (
+        "Try something descriptive like 'Weekend Movie Night' or "
+        "'Team Lunch Choice'"
+    ),
+    "question": (
+        "Be specific! Instead of 'Pick one', try "
+        "'Which movie should we watch this Friday?'"
+    ),
+    "server_id": "Choose the server where you want to post this poll",
+    "channel_id": "Choose the channel where you want to post this poll",
+    "options": (
+        "Add more choices for people to vote on. Great polls usually have "
+        "3-5 options!"
+    ),
+    "open_time": "Choose a time when your audience will be active",
+    "close_time": (
+        "Give people enough time to vote, but not too long that they forget"
+    ),
+    "max_choices": "Choose a reasonable number of choices users can select",
+    "ping_role_id": "Choose a role from the dropdown or disable role ping",
+}
+
+
 def validation_error_to_messages(exc: ValidationError) -> List[dict]:
-    """Convert a Pydantic ``ValidationError`` into the legacy error shape."""
+    """Convert a Pydantic ``ValidationError`` into the legacy error shape.
+
+    Restores per-field labels and suggestion text so end-users see the same
+    hints as the original hand-rolled validator.
+    """
     messages: List[dict] = []
     for err in exc.errors():
         msg = err.get("msg", "Invalid value")
         if msg.startswith("Value error, "):
             msg = msg[len("Value error, "):]
+
+        loc = err.get("loc") or ()
+        raw_field = str(loc[-1]) if loc else ""
+
         if ":" in msg:
             field_name, _, detail = msg.partition(":")
             field_name = field_name.strip()
             detail = detail.strip() or msg
         else:
-            loc = err.get("loc") or ()
-            field_name = (
-                str(loc[-1]).replace("_", " ").title() if loc else "Field"
+            field_name = _FIELD_LABELS.get(
+                raw_field,
+                raw_field.replace("_", " ").title() if raw_field else "Field",
             )
             detail = msg
-        messages.append({"field_name": field_name, "message": detail, "suggestion": ""})
+
+        messages.append(
+            {
+                "field_name": field_name,
+                "message": detail,
+                "suggestion": _FIELD_SUGGESTIONS.get(raw_field, ""),
+            }
+        )
     return messages
 
 

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -240,7 +240,18 @@ class PollFormRequest(BaseModel):
                 f"Poll Times: invalid date/time format ({value})"
             ) from exc
         if dt.tzinfo is None:
-            dt = tz.localize(dt)
+            try:
+                dt = tz.localize(dt, is_dst=None)
+            except pytz.AmbiguousTimeError as exc:
+                raise ValueError(
+                    f"Poll Times: {value} is ambiguous in {tz} (DST overlap); "
+                    "pick a time outside the transition"
+                ) from exc
+            except pytz.NonExistentTimeError as exc:
+                raise ValueError(
+                    f"Poll Times: {value} does not exist in {tz} (DST gap); "
+                    "pick a time outside the transition"
+                ) from exc
         return dt.astimezone(pytz.UTC)
 
     def _validate_time_window(
@@ -374,6 +385,19 @@ _FIELD_SUGGESTIONS = {
     "ping_role_id": "Choose a role from the dropdown or disable role ping",
 }
 
+# Reverse map of friendly labels → field key, used to rehydrate suggestion
+# lookup for model-level ValueErrors where Pydantic's ``loc`` is empty/root
+# but the message itself starts with the friendly label (e.g. "Role Selection: ...").
+_LABEL_TO_FIELD = {label: field for field, label in _FIELD_LABELS.items()}
+
+# Discord ID fields whose Pydantic pattern error should be translated to
+# the legacy user-friendly copy instead of "String should match pattern …".
+_DISCORD_ID_PATTERN_MESSAGES = {
+    "server_id": "Please select a Discord server",
+    "channel_id": "Please select a Discord channel",
+    "ping_role_id": "Must be a numeric Discord ID",
+}
+
 
 def validation_error_to_messages(exc: ValidationError) -> List[dict]:
     """Convert a Pydantic ``ValidationError`` into the legacy error shape.
@@ -384,6 +408,7 @@ def validation_error_to_messages(exc: ValidationError) -> List[dict]:
     messages: List[dict] = []
     for err in exc.errors():
         msg = err.get("msg", "Invalid value")
+        err_type = err.get("type", "")
         if msg.startswith("Value error, "):
             msg = msg[len("Value error, "):]
 
@@ -394,12 +419,21 @@ def validation_error_to_messages(exc: ValidationError) -> List[dict]:
             field_name, _, detail = msg.partition(":")
             field_name = field_name.strip()
             detail = detail.strip() or msg
+            # Rehydrate raw_field from the parsed label so suggestions still
+            # apply when the error came from a model_validator with empty loc.
+            if not raw_field:
+                raw_field = _LABEL_TO_FIELD.get(field_name, raw_field)
         else:
             field_name = _FIELD_LABELS.get(
                 raw_field,
                 raw_field.replace("_", " ").title() if raw_field else "Field",
             )
             detail = msg
+            if (
+                err_type == "string_pattern_mismatch"
+                and raw_field in _DISCORD_ID_PATTERN_MESSAGES
+            ):
+                detail = _DISCORD_ID_PATTERN_MESSAGES[raw_field]
 
         messages.append(
             {

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 from typing import Any, List, Optional, Tuple
 
 import pytz
-from fastapi import Request
+from fastapi import HTTPException, Request, status
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -358,20 +358,31 @@ def _extract_options(form_data: Any) -> List[str]:
 
 
 def poll_form_to_dict(form_data: Any) -> dict:
-    """Translate raw FastAPI ``FormData`` into a model_validate-ready dict."""
+    """Translate raw FastAPI ``FormData`` into a model_validate-ready dict.
+
+    Raw form values are passed through as-is wherever the model has its own
+    ``mode="before"`` validator that distinguishes "absent" from "explicit
+    falsy". That keeps tampered inputs (e.g. ``timezone=0``, ``max_choices=0``)
+    visible to the validator instead of silently collapsing to defaults.
+    """
+    raw_max_choices = form_data.get("max_choices")
     return {
         "name": form_data.get("name"),
         "question": form_data.get("question"),
         "server_id": form_data.get("server_id"),
         "channel_id": form_data.get("channel_id"),
         "options": _extract_options(form_data),
-        "timezone": form_data.get("timezone") or DEFAULT_TIMEZONE,
+        # Pass timezone through verbatim; _coerce_timezone defaults None and
+        # rejects non-strings instead of silently collapsing falsy garbage.
+        "timezone": form_data.get("timezone"),
         "open_time": form_data.get("open_time"),
         "close_time": form_data.get("close_time"),
         "open_immediately": _truthy(form_data.get("open_immediately")),
         "anonymous": _truthy(form_data.get("anonymous")),
         "multiple_choice": _truthy(form_data.get("multiple_choice")),
-        "max_choices": form_data.get("max_choices") or None,
+        # Only collapse the empty-string case; preserve other falsy values
+        # (e.g. ``"0"``) so _resolve_max_choices can range-check them.
+        "max_choices": None if raw_max_choices == "" else raw_max_choices,
         "ping_role_enabled": _truthy(form_data.get("ping_role_enabled")),
         "ping_role_id": form_data.get("ping_role_id"),
         "ping_role_on_close": _truthy(form_data.get("ping_role_on_close")),
@@ -526,8 +537,22 @@ def validation_error_to_messages(exc: ValidationError) -> List[dict]:
 async def parse_poll_form_request(request: Request) -> PollFormRequest:
     """FastAPI dependency: read the request form and return a validated model.
 
-    Raises ``pydantic.ValidationError`` when the payload is invalid; callers
-    should catch it and translate to whatever response the endpoint needs.
+    Raises ``HTTPException`` with status 422 (carrying the legacy-shaped
+    error messages in ``detail``) on invalid payloads, so failures surface
+    as proper client errors instead of bubbling to FastAPI's generic 500
+    handler.
     """
     form_data = await request.form()
-    return PollFormRequest.model_validate(poll_form_to_dict(form_data))
+    try:
+        return PollFormRequest.model_validate(poll_form_to_dict(form_data))
+    except ValidationError as exc:
+        # Some Starlette versions renamed the constant; fall back gracefully.
+        unprocessable = getattr(
+            status,
+            "HTTP_422_UNPROCESSABLE_CONTENT",
+            getattr(status, "HTTP_422_UNPROCESSABLE_ENTITY", 422),
+        )
+        raise HTTPException(
+            status_code=unprocessable,
+            detail=validation_error_to_messages(exc),
+        ) from exc

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -120,7 +120,10 @@ class PollFormRequest(BaseModel):
     ping_role_on_close: bool = False
     ping_role_on_update: bool = False
 
-    image_message_text: str = ""
+    # Discord caps message content at 2000 characters; validate up front
+    # so users see a friendly form error instead of an HTTPException at
+    # post time.
+    image_message_text: str = Field(default="", max_length=2000)
 
     # Internal scratch fields populated by ``_resolve_dependent_fields``;
     # excluded from schemas and ``model_dump()`` since they aren't part of
@@ -335,15 +338,21 @@ class VoteRequest(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
-    user_id: str = Field(..., min_length=1)
+    user_id: str = Field(..., min_length=1, pattern=r"^\d+$")
     option_index: int = Field(..., ge=0)
 
     @field_validator("user_id", mode="before")
     @classmethod
     def _coerce_user_id(cls, value: Any) -> Any:
-        if value is None:
-            return value
-        return str(value).strip()
+        # Restrict the coercion path to types Discord actually emits for
+        # user IDs (snowflake int or stringified int). Other shapes (dict,
+        # list, None) fall straight to Pydantic's type/missing checks
+        # rather than being silently turned into nonsense via str(...).
+        if isinstance(value, int):
+            return str(value)
+        if isinstance(value, str):
+            return value.strip()
+        return value
 
 
 def _extract_options(form_data: Any) -> List[str]:

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -475,11 +475,20 @@ def validation_error_to_messages(exc: ValidationError) -> List[dict]:
             detail_after_prefix = tail.strip() or msg
 
         if raw_field in _FIELD_LABELS:
-            # Concrete loc: trust the canonical label and drop any redundant
-            # "Label: ..." prefix from the message body so we don't render
-            # output like "Poll Options: Options: duplicates not allowed".
+            # Concrete loc: trust the canonical label and drop only the
+            # redundant "Field: ..." prefix from the body so output reads
+            # cleanly (e.g. avoid "Poll Options: Options: duplicates ...").
+            # We MUST keep informative prefixes like "Option 2: ..." that
+            # carry data the field label can't express.
             field_name = _FIELD_LABELS[raw_field]
-            detail = detail_after_prefix if prefix_label else msg
+            redundant_prefixes = {
+                field_name,
+                raw_field.replace("_", " ").title(),
+            }
+            if prefix_label and prefix_label in redundant_prefixes:
+                detail = detail_after_prefix
+            else:
+                detail = msg
         elif prefix_label:
             # No useful loc; fall back to the message-level prefix and
             # rehydrate raw_field via _LABEL_TO_FIELD for suggestion lookup.

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -131,9 +131,11 @@ class PollFormRequest(BaseModel):
     @field_validator("name", "question", mode="before")
     @classmethod
     def _sanitize_user_text(cls, value: Any) -> Any:
-        # Match legacy PollValidator.validate_poll_name: strip raw HTML/quote
-        # characters from user-controlled prose so payloads can't smuggle
-        # markup into templates, logs, or Discord embeds.
+        # Strip raw HTML/quote characters from user-controlled prose. The
+        # legacy validator only did this for ``name`` (PollValidator.
+        # validate_poll_name); we extend the same scrub to ``question`` as
+        # defense-in-depth, since both fields are rendered into HTMX
+        # templates, written to logs, and forwarded into Discord embeds.
         if isinstance(value, str):
             return re.sub(r'[<>"\']', "", value)
         return value
@@ -427,7 +429,7 @@ _DISCORD_ID_PRESENCE_MESSAGES = {
     "server_id": "Please select a Discord server",
     "channel_id": "Please select a Discord channel",
 }
-_DISCORD_ID_PRESENCE_TYPES = {"missing", "string_too_short"}
+_DISCORD_ID_PRESENCE_TYPES = {"missing", "string_too_short", "string_type"}
 
 
 def validation_error_to_messages(exc: ValidationError) -> List[dict]:

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -59,16 +59,16 @@ def _truthy(value: Any) -> bool:
 def _normalize_timezone(value: Optional[str]) -> str:
     """Normalize a user-supplied timezone identifier.
 
-    Returns the default timezone for missing/blank input but raises
+    Returns :data:`DEFAULT_TIMEZONE` for missing/blank input but raises
     ``ValueError`` for an explicitly malformed one, so tampered or typo'd
-    values fail validation instead of silently being shifted to Eastern.
+    values fail validation instead of silently being shifted to the default.
     """
     if not value:
-        return "US/Eastern"
+        return DEFAULT_TIMEZONE
     value = value.strip()
     if not value:
-        return "US/Eastern"
-    value = _TIMEZONE_ALIASES.get(value, value)
+        return DEFAULT_TIMEZONE
+    value = TIMEZONE_ALIASES.get(value, value)
     try:
         pytz.timezone(value)
     except pytz.UnknownTimeZoneError as exc:
@@ -103,7 +103,7 @@ class PollFormRequest(BaseModel):
     # legitimate user inputs. Templates that render this string must rely on
     # Jinja's autoescaping, not validator-side sanitization.
 
-    timezone: str = Field(default="US/Eastern")
+    timezone: str = Field(default=DEFAULT_TIMEZONE)
     open_time: Optional[str] = None
     close_time: Optional[str] = None
 
@@ -355,7 +355,7 @@ def poll_form_to_dict(form_data: Any) -> dict:
         "server_id": form_data.get("server_id"),
         "channel_id": form_data.get("channel_id"),
         "options": _extract_options(form_data),
-        "timezone": form_data.get("timezone") or "US/Eastern",
+        "timezone": form_data.get("timezone") or DEFAULT_TIMEZONE,
         "open_time": form_data.get("open_time"),
         "close_time": form_data.get("close_time"),
         "open_immediately": _truthy(form_data.get("open_immediately")),

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -169,7 +169,7 @@ class PollFormRequest(BaseModel):
         if value is None:
             return None
         if not value.isdigit():
-            raise ValueError("Role Id: must be a numeric Discord ID")
+            raise ValueError("Role Selection: must be a numeric Discord ID")
         return value
 
     @model_validator(mode="after")

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -54,15 +54,23 @@ def _truthy(value: Any) -> bool:
 
 
 def _normalize_timezone(value: Optional[str]) -> str:
-    """Normalize a user-supplied timezone identifier."""
+    """Normalize a user-supplied timezone identifier.
+
+    Returns the default timezone for missing/blank input but raises
+    ``ValueError`` for an explicitly malformed one, so tampered or typo'd
+    values fail validation instead of silently being shifted to Eastern.
+    """
+    if not value:
+        return "US/Eastern"
+    value = value.strip()
     if not value:
         return "US/Eastern"
     value = _TIMEZONE_ALIASES.get(value, value)
     try:
         pytz.timezone(value)
-        return value
-    except Exception:
-        return "US/Eastern"
+    except pytz.UnknownTimeZoneError as exc:
+        raise ValueError(f"Timezone: invalid timezone ({value})") from exc
+    return value
 
 
 class PollFormRequest(BaseModel):
@@ -124,12 +132,13 @@ class PollFormRequest(BaseModel):
         if isinstance(value, list):
             cleaned = []
             for item in value:
-                text = str(item).strip()
-                if not text:
-                    continue
                 # Match legacy PollValidator.validate_poll_options: drop
-                # bare quotes while keeping Discord <:emoji:id> markers intact.
-                cleaned.append(re.sub(r'["\']', "", text))
+                # bare quotes while keeping Discord <:emoji:id> markers
+                # intact, then re-strip so quote-only entries are dropped
+                # rather than collapsing to "".
+                text = re.sub(r'["\']', "", str(item).strip()).strip()
+                if text:
+                    cleaned.append(text)
             return cleaned
         return value
 

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -94,6 +94,12 @@ class PollFormRequest(BaseModel):
     channel_id: str = Field(..., min_length=1, pattern=r"^\d+$")
     options: List[str] = Field(..., min_length=2, max_length=10)
 
+    # ``image_message_text`` is intentionally NOT stripped of ``<>``: Discord
+    # interprets ``<@id>`` (mentions), ``<#id>`` (channels), and
+    # ``<:name:id>`` (custom emojis) — stripping them would break those
+    # legitimate user inputs. Templates that render this string must rely on
+    # Jinja's autoescaping, not validator-side sanitization.
+
     timezone: str = Field(default="US/Eastern")
     open_time: Optional[str] = None
     close_time: Optional[str] = None
@@ -118,6 +124,16 @@ class PollFormRequest(BaseModel):
     # the request payload.
     open_time_utc: Optional[datetime] = Field(default=None, exclude=True)
     close_time_utc: Optional[datetime] = Field(default=None, exclude=True)
+
+    @field_validator("name", "question", mode="before")
+    @classmethod
+    def _sanitize_user_text(cls, value: Any) -> Any:
+        # Match legacy PollValidator.validate_poll_name: strip raw HTML/quote
+        # characters from user-controlled prose so payloads can't smuggle
+        # markup into templates, logs, or Discord embeds.
+        if isinstance(value, str):
+            return re.sub(r'[<>"\']', "", value)
+        return value
 
     @field_validator("timezone", mode="before")
     @classmethod

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -251,30 +251,30 @@ class PollFormRequest(BaseModel):
                 raise ValueError(
                     "Open Time: please select when the poll should start"
                 )
-            open_dt = self._localize(self.open_time, tz)
+            open_dt = self._localize(self.open_time, tz, "Open Time")
 
-        close_dt = self._localize(self.close_time, tz)
+        close_dt = self._localize(self.close_time, tz, "Close Time")
         return open_dt, close_dt
 
     @staticmethod
-    def _localize(value: str, tz: Any) -> datetime:
+    def _localize(value: str, tz: Any, field_label: str = "Poll Times") -> datetime:
         try:
             dt = datetime.fromisoformat(value)
         except ValueError as exc:
             raise ValueError(
-                f"Poll Times: invalid date/time format ({value})"
+                f"{field_label}: invalid date/time format ({value})"
             ) from exc
         if dt.tzinfo is None:
             try:
                 dt = tz.localize(dt, is_dst=None)
             except pytz.AmbiguousTimeError as exc:
                 raise ValueError(
-                    f"Poll Times: {value} is ambiguous in {tz} (DST overlap); "
+                    f"{field_label}: {value} is ambiguous in {tz} (DST overlap); "
                     "pick a time outside the transition"
                 ) from exc
             except pytz.NonExistentTimeError as exc:
                 raise ValueError(
-                    f"Poll Times: {value} does not exist in {tz} (DST gap); "
+                    f"{field_label}: {value} does not exist in {tz} (DST gap); "
                     "pick a time outside the transition"
                 ) from exc
         else:

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -296,12 +296,12 @@ class PollFormRequest(BaseModel):
                     "Close Time: must be in the future for immediate polls"
                 )
         else:
-            user_tz = pytz.timezone(self.timezone)
-            now_local = now.astimezone(user_tz)
-            next_minute_local = now_local.replace(
+            # Compute the floor of the next minute directly in UTC to avoid
+            # naive timedelta arithmetic on a pytz-aware local datetime,
+            # which can produce wrong offsets across DST boundaries.
+            next_minute_utc = now.replace(
                 second=0, microsecond=0
             ) + timedelta(minutes=1)
-            next_minute_utc = next_minute_local.astimezone(pytz.UTC)
             if open_dt < next_minute_utc:
                 raise ValueError(
                     "Open Time: must be scheduled for at least the next full minute"

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -26,7 +26,7 @@ from pydantic import (
 )
 
 
-_TIMEZONE_ALIASES = {
+TIMEZONE_ALIASES = {
     "EDT": "US/Eastern",
     "EST": "US/Eastern",
     "CDT": "US/Central",
@@ -40,6 +40,9 @@ _TIMEZONE_ALIASES = {
     "Mountain": "US/Mountain",
     "Pacific": "US/Pacific",
 }
+DEFAULT_TIMEZONE = "US/Eastern"
+# Backwards-compatible private alias for code that already imports the old name.
+_TIMEZONE_ALIASES = TIMEZONE_ALIASES
 
 _TRUE_STRINGS = {"true", "1", "on", "yes"}
 
@@ -416,6 +419,16 @@ _DISCORD_ID_PATTERN_MESSAGES = {
     "ping_role_id": "Must be a numeric Discord ID",
 }
 
+# When a required Discord ID is missing or blank (most often an unselected
+# dropdown), surface the same friendly copy used for pattern mismatches
+# instead of leaking Pydantic's "Field required" / "String should have at
+# least 1 character" wording.
+_DISCORD_ID_PRESENCE_MESSAGES = {
+    "server_id": "Please select a Discord server",
+    "channel_id": "Please select a Discord channel",
+}
+_DISCORD_ID_PRESENCE_TYPES = {"missing", "string_too_short"}
+
 
 def validation_error_to_messages(exc: ValidationError) -> List[dict]:
     """Convert a Pydantic ``ValidationError`` into the legacy error shape.
@@ -452,6 +465,11 @@ def validation_error_to_messages(exc: ValidationError) -> List[dict]:
                 and raw_field in _DISCORD_ID_PATTERN_MESSAGES
             ):
                 detail = _DISCORD_ID_PATTERN_MESSAGES[raw_field]
+            elif (
+                err_type in _DISCORD_ID_PRESENCE_TYPES
+                and raw_field in _DISCORD_ID_PRESENCE_MESSAGES
+            ):
+                detail = _DISCORD_ID_PRESENCE_MESSAGES[raw_field]
 
         messages.append(
             {

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -413,6 +413,12 @@ _FIELD_SUGGESTIONS = {
 # but the message itself starts with the friendly label (e.g. "Role Selection: ...").
 _LABEL_TO_FIELD = {label: field for field, label in _FIELD_LABELS.items()}
 
+# Synthetic prefixes used by model-level validators that don't correspond to
+# a single field. ``_LABEL_TO_FIELD`` maps them to a real key in
+# ``_FIELD_SUGGESTIONS`` so the wrapper still attaches a useful hint.
+_LABEL_TO_FIELD["Poll Duration"] = "close_time"
+_LABEL_TO_FIELD["Poll Times"] = "open_time"
+
 # Discord ID fields whose Pydantic pattern error should be translated to
 # the legacy user-friendly copy instead of "String should match pattern …".
 _DISCORD_ID_PATTERN_MESSAGES = {
@@ -436,7 +442,10 @@ def validation_error_to_messages(exc: ValidationError) -> List[dict]:
     """Convert a Pydantic ``ValidationError`` into the legacy error shape.
 
     Restores per-field labels and suggestion text so end-users see the same
-    hints as the original hand-rolled validator.
+    hints as the original hand-rolled validator. When Pydantic provides a
+    concrete ``loc``, that field's canonical label always wins over any
+    ``"Label: ..."`` prefix in the raw message; a colon prefix is only used
+    as the source of truth when ``loc`` is empty (model-level validators).
     """
     messages: List[dict] = []
     for err in exc.errors():
@@ -448,30 +457,47 @@ def validation_error_to_messages(exc: ValidationError) -> List[dict]:
         loc = err.get("loc") or ()
         raw_field = str(loc[-1]) if loc else ""
 
+        # Split off any "Label: detail" prefix up front so we can use the
+        # detail body regardless of which source wins for ``field_name``.
+        prefix_label = ""
+        detail_after_prefix = msg
         if ":" in msg:
-            field_name, _, detail = msg.partition(":")
-            field_name = field_name.strip()
-            detail = detail.strip() or msg
-            # Rehydrate raw_field from the parsed label so suggestions still
-            # apply when the error came from a model_validator with empty loc.
+            head, _, tail = msg.partition(":")
+            prefix_label = head.strip()
+            detail_after_prefix = tail.strip() or msg
+
+        if raw_field in _FIELD_LABELS:
+            # Concrete loc: trust the canonical label and drop the redundant
+            # prefix from the message body when it matches.
+            field_name = _FIELD_LABELS[raw_field]
+            detail = (
+                detail_after_prefix
+                if prefix_label and prefix_label == field_name
+                else msg
+            )
+        elif prefix_label:
+            # No useful loc; fall back to the message-level prefix and
+            # rehydrate raw_field via _LABEL_TO_FIELD for suggestion lookup.
+            field_name = prefix_label
+            detail = detail_after_prefix
             if not raw_field:
-                raw_field = _LABEL_TO_FIELD.get(field_name, raw_field)
+                raw_field = _LABEL_TO_FIELD.get(prefix_label, raw_field)
         else:
-            field_name = _FIELD_LABELS.get(
-                raw_field,
-                raw_field.replace("_", " ").title() if raw_field else "Field",
+            field_name = (
+                raw_field.replace("_", " ").title() if raw_field else "Field"
             )
             detail = msg
-            if (
-                err_type == "string_pattern_mismatch"
-                and raw_field in _DISCORD_ID_PATTERN_MESSAGES
-            ):
-                detail = _DISCORD_ID_PATTERN_MESSAGES[raw_field]
-            elif (
-                err_type in _DISCORD_ID_PRESENCE_TYPES
-                and raw_field in _DISCORD_ID_PRESENCE_MESSAGES
-            ):
-                detail = _DISCORD_ID_PRESENCE_MESSAGES[raw_field]
+
+        if (
+            err_type == "string_pattern_mismatch"
+            and raw_field in _DISCORD_ID_PATTERN_MESSAGES
+        ):
+            detail = _DISCORD_ID_PATTERN_MESSAGES[raw_field]
+        elif (
+            err_type in _DISCORD_ID_PRESENCE_TYPES
+            and raw_field in _DISCORD_ID_PRESENCE_MESSAGES
+        ):
+            detail = _DISCORD_ID_PRESENCE_MESSAGES[raw_field]
 
         messages.append(
             {

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -131,13 +131,14 @@ class PollFormRequest(BaseModel):
     @field_validator("name", "question", mode="before")
     @classmethod
     def _sanitize_user_text(cls, value: Any) -> Any:
-        # Strip raw HTML/quote characters from user-controlled prose. The
-        # legacy validator only did this for ``name`` (PollValidator.
-        # validate_poll_name); we extend the same scrub to ``question`` as
-        # defense-in-depth, since both fields are rendered into HTMX
-        # templates, written to logs, and forwarded into Discord embeds.
+        # Strip only raw angle brackets so payloads can't smuggle HTML/JS
+        # markup into templates, logs, or Discord embeds. Apostrophes and
+        # quotes are legitimate punctuation ("don't", "Friday's vote") and
+        # are safely handled by Jinja autoescaping on the way out — we
+        # deliberately diverge from legacy validate_poll_name's broader
+        # quote scrub so user prose isn't mangled.
         if isinstance(value, str):
-            return re.sub(r'[<>"\']', "", value)
+            return re.sub(r'[<>]', "", value)
         return value
 
     @field_validator("timezone", mode="before")

--- a/polly/poll_request_models.py
+++ b/polly/poll_request_models.py
@@ -1,0 +1,311 @@
+"""
+Pydantic v2 request models for poll create/update/vote.
+
+Centralizes form-data parsing and validation so endpoint handlers can rely
+on a typed, validated payload instead of scattered ``form_data.get(...)``
+calls. Use :func:`parse_poll_form_request` as a FastAPI dependency
+(``Depends(parse_poll_form_request)``) to obtain a validated
+:class:`PollFormRequest` from any form-encoded request body.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any, List, Optional, Tuple
+
+import pytz
+from fastapi import Request
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+try:
+    from .debug_config import get_debug_logger
+except ImportError:  # pragma: no cover - script-mode imports
+    from debug_config import get_debug_logger  # type: ignore
+
+logger = get_debug_logger(__name__)
+
+
+_TIMEZONE_ALIASES = {
+    "EDT": "US/Eastern",
+    "EST": "US/Eastern",
+    "CDT": "US/Central",
+    "CST": "US/Central",
+    "MDT": "US/Mountain",
+    "MST": "US/Mountain",
+    "PDT": "US/Pacific",
+    "PST": "US/Pacific",
+    "Eastern": "US/Eastern",
+    "Central": "US/Central",
+    "Mountain": "US/Mountain",
+    "Pacific": "US/Pacific",
+}
+
+_TRUE_STRINGS = {"true", "1", "on", "yes"}
+
+
+def _truthy(value: Any) -> bool:
+    """Best-effort coercion of HTML form values to ``bool``."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in _TRUE_STRINGS
+
+
+def _normalize_timezone(value: Optional[str]) -> str:
+    """Normalize a user-supplied timezone identifier."""
+    if not value:
+        return "US/Eastern"
+    value = _TIMEZONE_ALIASES.get(value, value)
+    try:
+        pytz.timezone(value)
+        return value
+    except Exception:
+        return "US/Eastern"
+
+
+class PollFormRequest(BaseModel):
+    """Validated form payload for poll create/update endpoints.
+
+    The same shape backs both endpoints because the edit form is a
+    superset of the create form (existing fields must still validate).
+    Aliases :class:`PollCreateRequest` and :class:`PollUpdateRequest` are
+    exported below for call-site clarity.
+    """
+
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+    name: str = Field(..., min_length=3, max_length=255)
+    question: str = Field(..., min_length=5, max_length=2000)
+    server_id: str = Field(..., min_length=1)
+    channel_id: str = Field(..., min_length=1)
+    options: List[str] = Field(..., min_length=2, max_length=10)
+
+    timezone: str = Field(default="US/Eastern")
+    open_time: Optional[str] = None
+    close_time: Optional[str] = None
+
+    open_immediately: bool = False
+    anonymous: bool = False
+    multiple_choice: bool = False
+    max_choices: Optional[int] = Field(default=None, ge=2, le=10)
+
+    ping_role_enabled: bool = False
+    ping_role_id: Optional[str] = None
+    ping_role_on_close: bool = False
+    ping_role_on_update: bool = False
+
+    image_message_text: str = ""
+
+    open_time_utc: Optional[datetime] = None
+    close_time_utc: Optional[datetime] = None
+
+    @field_validator("timezone", mode="before")
+    @classmethod
+    def _coerce_timezone(cls, value: Any) -> str:
+        return _normalize_timezone(value if isinstance(value, str) else None)
+
+    @field_validator("options", mode="before")
+    @classmethod
+    def _strip_options(cls, value: Any) -> Any:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        return value
+
+    @field_validator("ping_role_id", mode="before")
+    @classmethod
+    def _empty_role_to_none(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
+
+    @model_validator(mode="after")
+    def _resolve_dependent_fields(self) -> "PollFormRequest":
+        if not self.multiple_choice:
+            self.max_choices = None
+
+        if not self.ping_role_enabled:
+            self.ping_role_id = None
+            self.ping_role_on_close = False
+            self.ping_role_on_update = False
+        elif not self.ping_role_id:
+            raise ValueError(
+                "Role Selection: please select a role to ping when role ping is enabled"
+            )
+
+        open_dt, close_dt = self._parse_times()
+        self._validate_time_window(open_dt, close_dt)
+        self.open_time_utc = open_dt
+        self.close_time_utc = close_dt
+        return self
+
+    def _parse_times(self) -> Tuple[datetime, datetime]:
+        if not self.close_time:
+            raise ValueError(
+                "Close Time: please select when the poll should end"
+            )
+        tz = pytz.timezone(self.timezone)
+
+        if self.open_immediately:
+            open_dt = datetime.now(pytz.UTC)
+        else:
+            if not self.open_time:
+                raise ValueError(
+                    "Open Time: please select when the poll should start"
+                )
+            open_dt = self._localize(self.open_time, tz)
+
+        close_dt = self._localize(self.close_time, tz)
+        return open_dt, close_dt
+
+    @staticmethod
+    def _localize(value: str, tz: Any) -> datetime:
+        try:
+            dt = datetime.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"Poll Times: invalid date/time format ({value})"
+            ) from exc
+        if dt.tzinfo is None:
+            dt = tz.localize(dt)
+        return dt.astimezone(pytz.UTC)
+
+    def _validate_time_window(
+        self, open_dt: datetime, close_dt: datetime
+    ) -> None:
+        now = datetime.now(pytz.UTC)
+        if self.open_immediately:
+            if close_dt <= now:
+                raise ValueError(
+                    "Close Time: must be in the future for immediate polls"
+                )
+        else:
+            user_tz = pytz.timezone(self.timezone)
+            now_local = now.astimezone(user_tz)
+            next_minute_local = now_local.replace(
+                second=0, microsecond=0
+            ) + timedelta(minutes=1)
+            next_minute_utc = next_minute_local.astimezone(pytz.UTC)
+            if open_dt < next_minute_utc:
+                raise ValueError(
+                    "Open Time: must be scheduled for at least the next full minute"
+                )
+            if close_dt <= open_dt:
+                raise ValueError(
+                    "Close Time: must be after the open time"
+                )
+
+        duration = close_dt - open_dt
+        if duration < timedelta(minutes=1):
+            raise ValueError(
+                "Poll Duration: poll must run for at least 1 minute"
+            )
+        if duration > timedelta(days=30):
+            raise ValueError(
+                "Poll Duration: poll cannot run for more than 30 days"
+            )
+
+
+PollCreateRequest = PollFormRequest
+PollUpdateRequest = PollFormRequest
+
+
+class VoteRequest(BaseModel):
+    """Validated payload for casting a vote.
+
+    Used by both the bot's reaction handler and any future HTTP vote
+    endpoint so option index + user id constraints live in one place.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    user_id: str = Field(..., min_length=1)
+    option_index: int = Field(..., ge=0)
+
+    @field_validator("user_id", mode="before")
+    @classmethod
+    def _coerce_user_id(cls, value: Any) -> Any:
+        if value is None:
+            return value
+        return str(value).strip()
+
+
+def _extract_options(form_data: Any) -> List[str]:
+    options: List[str] = []
+    for i in range(1, 11):
+        value = form_data.get(f"option{i}")
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            options.append(text)
+    return options
+
+
+def poll_form_to_dict(form_data: Any) -> dict:
+    """Translate raw FastAPI ``FormData`` into a model_validate-ready dict."""
+    return {
+        "name": form_data.get("name"),
+        "question": form_data.get("question"),
+        "server_id": form_data.get("server_id"),
+        "channel_id": form_data.get("channel_id"),
+        "options": _extract_options(form_data),
+        "timezone": form_data.get("timezone") or "US/Eastern",
+        "open_time": form_data.get("open_time"),
+        "close_time": form_data.get("close_time"),
+        "open_immediately": _truthy(form_data.get("open_immediately")),
+        "anonymous": _truthy(form_data.get("anonymous")),
+        "multiple_choice": _truthy(form_data.get("multiple_choice")),
+        "max_choices": form_data.get("max_choices") or None,
+        "ping_role_enabled": _truthy(form_data.get("ping_role_enabled")),
+        "ping_role_id": form_data.get("ping_role_id"),
+        "ping_role_on_close": _truthy(form_data.get("ping_role_on_close")),
+        "ping_role_on_update": _truthy(form_data.get("ping_role_on_update")),
+        "image_message_text": form_data.get("image_message_text") or "",
+    }
+
+
+def validation_error_to_messages(exc: ValidationError) -> List[dict]:
+    """Convert a Pydantic ``ValidationError`` into the legacy error shape."""
+    messages: List[dict] = []
+    for err in exc.errors():
+        msg = err.get("msg", "Invalid value")
+        if msg.startswith("Value error, "):
+            msg = msg[len("Value error, "):]
+        if ":" in msg:
+            field_name, _, detail = msg.partition(":")
+            field_name = field_name.strip()
+            detail = detail.strip() or msg
+        else:
+            loc = err.get("loc") or ()
+            field_name = (
+                str(loc[-1]).replace("_", " ").title() if loc else "Field"
+            )
+            detail = msg
+        messages.append({"field_name": field_name, "message": detail, "suggestion": ""})
+    return messages
+
+
+async def parse_poll_form_request(request: Request) -> PollFormRequest:
+    """FastAPI dependency: read the request form and return a validated model.
+
+    Raises ``pydantic.ValidationError`` when the payload is invalid; callers
+    should catch it and translate to whatever response the endpoint needs.
+    """
+    form_data = await request.form()
+    return PollFormRequest.model_validate(poll_form_to_dict(form_data))

--- a/polly/validators.py
+++ b/polly/validators.py
@@ -653,9 +653,17 @@ class VoteValidator:
                 {"user_id": user_id, "option_index": option_index}
             )
         except PydanticValidationError as exc:
-            first = exc.errors()[0] if exc.errors() else {"msg": "Invalid vote"}
-            field = first.get("loc", ("vote",))[-1]
-            raise ValidationError(first.get("msg", "Invalid vote"), str(field))
+            first = exc.errors()[0] if exc.errors() else {}
+            loc = first.get("loc") or ("vote",)
+            field = str(loc[-1])
+            # Map Pydantic constraint failures back to the legacy
+            # user-friendly messages instead of leaking raw text like
+            # "Input should be greater than or equal to 0".
+            friendly = {
+                "user_id": "Invalid user ID",
+                "option_index": "Invalid option selection",
+            }
+            raise ValidationError(friendly.get(field, "Invalid vote"), field)
 
         user_id, option_index = request.user_id, request.option_index
 

--- a/polly/validators.py
+++ b/polly/validators.py
@@ -10,8 +10,12 @@ from typing import List, Dict, Any, Tuple, Optional
 import logging
 try:
     from .database import Poll, Vote, get_db_session
+    from .poll_request_models import VoteRequest
 except ImportError:
     from database import Poll, Vote, get_db_session  # type: ignore
+    from poll_request_models import VoteRequest  # type: ignore
+
+from pydantic import ValidationError as PydanticValidationError
 logger = logging.getLogger(__name__)
 
 
@@ -644,11 +648,16 @@ class VoteValidator:
         if str(poll.status) != "active":
             raise ValidationError("Poll is not active for voting")
 
-        if not user_id or not isinstance(user_id, str):
-            raise ValidationError("Invalid user ID")
+        try:
+            request = VoteRequest.model_validate(
+                {"user_id": user_id, "option_index": option_index}
+            )
+        except PydanticValidationError as exc:
+            first = exc.errors()[0] if exc.errors() else {"msg": "Invalid vote"}
+            field = first.get("loc", ("vote",))[-1]
+            raise ValidationError(first.get("msg", "Invalid vote"), str(field))
 
-        if not isinstance(option_index, int) or option_index < 0:
-            raise ValidationError("Invalid option selection")
+        user_id, option_index = request.user_id, request.option_index
 
         if option_index >= len(poll.options):
             raise ValidationError("Selected option does not exist")

--- a/polly/validators.py
+++ b/polly/validators.py
@@ -66,8 +66,11 @@ class PollValidator:
                 "name",
             )
 
-        # Remove potentially harmful characters
-        name = re.sub(r'[<>"\']', "", name)
+        # Strip raw angle brackets to prevent HTML/JS smuggling, but
+        # preserve apostrophes/quotes as legitimate punctuation. This
+        # mirrors PollFormRequest._sanitize_user_text so model-validated
+        # data survives the legacy validator unchanged.
+        name = re.sub(r'[<>]', "", name)
 
         return name
 

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -64,12 +64,13 @@ class TestPollFormRequestHappyPath:
         assert m.close_time_utc > m.open_time_utc
 
     def test_open_immediately_skips_open_time(self):
-        # When opening immediately, close_time must be relative to *now*,
-        # not the fixed-future _future() helper, since the duration is
-        # measured from the current moment.
-        close_dt = datetime.now(pytz.timezone("US/Pacific")) + timedelta(hours=2)
+        # When opening immediately, close_time must be relative to *now*.
+        # Use UTC (DST-free) so the derived wall-clock can never land in a
+        # DST gap/overlap that would trip ``tz.localize(..., is_dst=None)``.
+        close_dt = datetime.now(pytz.UTC) + timedelta(hours=2)
         m = _validate(
             _base_form(
+                timezone="UTC",
                 open_immediately="true",
                 open_time="",
                 close_time=close_dt.replace(microsecond=0).strftime("%Y-%m-%dT%H:%M"),

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -1,14 +1,17 @@
 """Unit tests for ``polly.poll_request_models``."""
 
+import asyncio
 from datetime import datetime, timedelta
 
 import pytest
 import pytz
+from fastapi import HTTPException
 from pydantic import ValidationError
 
 from polly.poll_request_models import (
     PollFormRequest,
     VoteRequest,
+    parse_poll_form_request,
     poll_form_to_dict,
     validation_error_to_messages,
 )
@@ -242,6 +245,52 @@ class TestPollFormRequestFailures:
         with pytest.raises(ValidationError) as exc:
             _validate(_base_form(timezone=["US/Eastern"]))
         assert "invalid timezone" in str(exc.value).lower()
+
+    def test_falsy_non_string_timezone_reaches_validator(self):
+        # Tampered falsy non-string (e.g. False) used to be silently
+        # collapsed by poll_form_to_dict before the validator could see
+        # it. Now the raw value should reach _coerce_timezone and be
+        # rejected.
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(timezone=False))
+        assert "invalid timezone" in str(exc.value).lower()
+
+
+class TestPollFormDictPassthrough:
+    """Behavioral tests for ``poll_form_to_dict``."""
+
+    def test_max_choices_zero_preserved(self):
+        # Empty string maps to None; other falsy values must reach the
+        # model so _resolve_max_choices can range-check them.
+        d = poll_form_to_dict(
+            _FormShim(
+                {
+                    **dict(_base_form()),
+                    "multiple_choice": "true",
+                    "max_choices": "0",
+                }
+            )
+        )
+        assert d["max_choices"] == "0"
+
+    def test_max_choices_empty_string_collapses_to_none(self):
+        d = poll_form_to_dict(
+            _FormShim({**dict(_base_form()), "max_choices": ""})
+        )
+        assert d["max_choices"] is None
+
+
+class TestParsePollFormRequest:
+    def test_validation_error_becomes_http_422(self):
+        class _FakeRequest:
+            async def form(self):
+                form = _base_form(server_id="abc")  # invalid pattern
+                return _FormShim(dict(form))
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(parse_poll_form_request(_FakeRequest()))
+        assert exc.value.status_code == 422
+        assert exc.value.detail and exc.value.detail[0]["field_name"] == "Server"
 
     def test_duration_too_short(self):
         # Fixed summer noon -> safely outside any DST transition.

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -211,7 +211,27 @@ class TestValidationErrorToMessages:
             _validate(_base_form(server_id="abc"))
         msgs = validation_error_to_messages(exc.value)
         assert msgs and msgs[0]["field_name"] == "Server"
+        assert msgs[0]["message"] == "Please select a Discord server"
         assert "post this poll" in msgs[0]["suggestion"]
+
+    def test_channel_pattern_failure_uses_friendly_copy(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(channel_id="bad"))
+        msgs = validation_error_to_messages(exc.value)
+        assert msgs[0]["field_name"] == "Channel"
+        assert msgs[0]["message"] == "Please select a Discord channel"
+
+    def test_model_level_value_error_keeps_suggestion(self):
+        # Role-Selection error originates from a model_validator and has
+        # an empty ``loc``; the wrapper should still attach the role-ping
+        # suggestion based on the parsed label.
+        with pytest.raises(ValidationError) as exc:
+            _validate(
+                _base_form(ping_role_enabled="true", ping_role_id="")
+            )
+        msgs = validation_error_to_messages(exc.value)
+        assert msgs[0]["field_name"] == "Role Selection"
+        assert "disable role ping" in msgs[0]["suggestion"]
 
     def test_min_length_failure_uses_friendly_label(self):
         with pytest.raises(ValidationError) as exc:

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -195,6 +195,35 @@ class TestPollFormRequestFailures:
             _validate(_base_form(timezone="Mars/Phobos"))
         assert "invalid timezone" in str(exc.value).lower()
 
+    def test_duration_too_short(self):
+        tz = pytz.timezone("US/Pacific")
+        open_dt = (
+            (datetime.now(tz) + timedelta(hours=2))
+            .replace(second=0, microsecond=0)
+        )
+        # 30 seconds after open -> duration below the 1-minute floor.
+        close_dt = open_dt + timedelta(seconds=30)
+        with pytest.raises(ValidationError) as exc:
+            _validate(
+                _base_form(
+                    open_time=open_dt.strftime("%Y-%m-%dT%H:%M:%S"),
+                    close_time=close_dt.strftime("%Y-%m-%dT%H:%M:%S"),
+                )
+            )
+        assert "at least 1 minute" in str(exc.value)
+
+    def test_duration_too_long(self):
+        tz = pytz.timezone("US/Pacific")
+        open_t = _future(2)
+        close_t = (
+            (datetime.now(tz) + timedelta(days=31))
+            .replace(microsecond=0)
+            .strftime("%Y-%m-%dT%H:%M")
+        )
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(open_time=open_t, close_time=close_t))
+        assert "30 days" in str(exc.value)
+
 
 class TestValidationErrorToMessages:
     def test_translates_value_error_with_field_prefix(self):

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -190,7 +190,18 @@ class TestPollFormRequestFailures:
     def test_invalid_close_time_format(self):
         with pytest.raises(ValidationError) as exc:
             _validate(_base_form(close_time="not-a-date"))
-        assert "invalid date/time format" in str(exc.value).lower()
+        # Error must be anchored to "Close Time" specifically so the UI
+        # can highlight the right field and show the right suggestion.
+        msg = str(exc.value)
+        assert "close time" in msg.lower()
+        assert "invalid date/time format" in msg.lower()
+
+    def test_invalid_open_time_format_anchored_to_open_time(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(open_time="not-a-date"))
+        msg = str(exc.value)
+        assert "open time" in msg.lower()
+        assert "invalid date/time format" in msg.lower()
 
     def test_non_numeric_server_id(self):
         with pytest.raises(ValidationError):

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -117,14 +117,26 @@ class TestPollFormRequestHappyPath:
         assert m.options == ["foobar", "bazqux"]
 
     def test_html_stripped_from_name_and_question(self):
+        # Angle brackets get scrubbed, but legitimate punctuation such as
+        # apostrophes and quotes (e.g. "don't", "Friday's vote") survive.
         m = _validate(
             _base_form(
-                name='<script>"Sample"</script>',
+                name="<script>Sample</script>",
                 question="Which option<br/> do 'you' prefer?",
             )
         )
         assert m.name == "scriptSample/script"
-        assert m.question == "Which optionbr/ do you prefer?"
+        assert m.question == "Which optionbr/ do 'you' prefer?"
+
+    def test_apostrophes_and_quotes_preserved(self):
+        m = _validate(
+            _base_form(
+                name="Friday's pick",
+                question='Which "movie" should we watch?',
+            )
+        )
+        assert m.name == "Friday's pick"
+        assert m.question == 'Which "movie" should we watch?'
 
     def test_image_message_text_preserves_discord_markup(self):
         # <@user>, <#channel>, <:emoji:id> must survive — they're Discord

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -183,6 +183,18 @@ class TestPollFormRequestFailures:
         with pytest.raises(ValidationError):
             _validate(_base_form(name="no"))
 
+    def test_quote_only_option_dropped(self):
+        # "''" collapses to "" after quote stripping; leaves only one
+        # real option so the 2-minimum constraint should fire.
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(option2="''"))
+        assert "at least 2" in str(exc.value)
+
+    def test_invalid_timezone_rejected(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(timezone="Mars/Phobos"))
+        assert "invalid timezone" in str(exc.value).lower()
+
 
 class TestValidationErrorToMessages:
     def test_translates_value_error_with_field_prefix(self):

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -236,6 +236,13 @@ class TestPollFormRequestFailures:
             _validate(_base_form(timezone="Mars/Phobos"))
         assert "invalid timezone" in str(exc.value).lower()
 
+    def test_non_string_timezone_rejected(self):
+        # A list/int reaching the timezone field is treated as tampered
+        # input rather than silently defaulting to DEFAULT_TIMEZONE.
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(timezone=["US/Eastern"]))
+        assert "invalid timezone" in str(exc.value).lower()
+
     def test_duration_too_short(self):
         # Fixed summer noon -> safely outside any DST transition.
         base = pytz.timezone("US/Pacific").localize(datetime(2099, 6, 15, 12, 0))
@@ -324,12 +331,15 @@ class TestValidationErrorToMessages:
     def test_loc_label_wins_over_message_prefix(self):
         # _validate_option_items raises "Options: ..." but Pydantic
         # supplies loc=("options",). The canonical "Poll Options" label
-        # must win over the "Options" prefix in the raw message.
+        # must win over the "Options" prefix in the raw message AND the
+        # redundant prefix must be stripped from the message body so the
+        # rendered output isn't "Poll Options: Options: ...".
         with pytest.raises(ValidationError) as exc:
             _validate(_base_form(option2="alpha"))  # duplicate
         msgs = validation_error_to_messages(exc.value)
         assert msgs[0]["field_name"] == "Poll Options"
         assert "duplicate" in msgs[0]["message"].lower()
+        assert not msgs[0]["message"].lower().startswith("options:")
         assert "Add more choices" in msgs[0]["suggestion"]
 
     def test_poll_duration_prefix_attaches_suggestion(self):

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -321,6 +321,35 @@ class TestValidationErrorToMessages:
         assert msgs[0]["field_name"] == "Role Selection"
         assert "disable role ping" in msgs[0]["suggestion"]
 
+    def test_loc_label_wins_over_message_prefix(self):
+        # _validate_option_items raises "Options: ..." but Pydantic
+        # supplies loc=("options",). The canonical "Poll Options" label
+        # must win over the "Options" prefix in the raw message.
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(option2="alpha"))  # duplicate
+        msgs = validation_error_to_messages(exc.value)
+        assert msgs[0]["field_name"] == "Poll Options"
+        assert "duplicate" in msgs[0]["message"].lower()
+        assert "Add more choices" in msgs[0]["suggestion"]
+
+    def test_poll_duration_prefix_attaches_suggestion(self):
+        # Duration error from _validate_time_window has no loc; the
+        # synthetic "Poll Duration" prefix should still resolve to the
+        # close_time suggestion via _LABEL_TO_FIELD.
+        base = pytz.timezone("US/Pacific").localize(datetime(2099, 6, 15, 12, 0))
+        open_dt = base
+        close_dt = open_dt + timedelta(seconds=30)
+        with pytest.raises(ValidationError) as exc:
+            _validate(
+                _base_form(
+                    open_time=open_dt.strftime("%Y-%m-%dT%H:%M:%S"),
+                    close_time=close_dt.strftime("%Y-%m-%dT%H:%M:%S"),
+                )
+            )
+        msgs = validation_error_to_messages(exc.value)
+        assert msgs[0]["field_name"] == "Poll Duration"
+        assert msgs[0]["suggestion"]  # non-empty, sourced from close_time
+
     def test_min_length_failure_uses_friendly_label(self):
         with pytest.raises(ValidationError) as exc:
             _validate(_base_form(name="no"))

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -298,6 +298,17 @@ class TestValidationErrorToMessages:
         assert msgs[0]["field_name"] == "Server"
         assert msgs[0]["message"] == "Please select a Discord server"
 
+    def test_absent_channel_id_uses_friendly_copy(self):
+        # An entirely missing form key reaches Pydantic as None ->
+        # ``string_type`` error; must still resolve to the friendly copy.
+        form = _base_form()
+        form["channel_id"] = None
+        with pytest.raises(ValidationError) as exc:
+            _validate(form)
+        msgs = validation_error_to_messages(exc.value)
+        assert msgs[0]["field_name"] == "Channel"
+        assert msgs[0]["message"] == "Please select a Discord channel"
+
     def test_model_level_value_error_keeps_suggestion(self):
         # Role-Selection error originates from a model_validator and has
         # an empty ``loc``; the wrapper should still attach the role-ping

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -90,6 +90,24 @@ class TestPollFormRequestHappyPath:
         m = _validate(_base_form(option1='foo"bar', option2="baz'qux"))
         assert m.options == ["foobar", "bazqux"]
 
+    def test_html_stripped_from_name_and_question(self):
+        m = _validate(
+            _base_form(
+                name='<script>"Sample"</script>',
+                question="Which option<br/> do 'you' prefer?",
+            )
+        )
+        assert m.name == "scriptSample/script"
+        assert m.question == "Which optionbr/ do you prefer?"
+
+    def test_image_message_text_preserves_discord_markup(self):
+        # <@user>, <#channel>, <:emoji:id> must survive — they're Discord
+        # markdown, not HTML.
+        m = _validate(
+            _base_form(image_message_text="ping <@123> in <#456> :: <:smile:789>")
+        )
+        assert m.image_message_text == "ping <@123> in <#456> :: <:smile:789>"
+
     def test_internal_utc_fields_excluded_from_dump(self):
         m = _validate(_base_form())
         dumped = m.model_dump()

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -86,6 +86,14 @@ class TestPollFormRequestHappyPath:
         assert m.ping_role_id is None
         assert m.ping_role_on_close is False
 
+    def test_non_numeric_ping_role_id_ignored_when_disabled(self):
+        # A stale or tampered non-numeric ping_role_id must not fail
+        # validation when role ping is off — legacy behavior was to drop it.
+        m = _validate(
+            _base_form(ping_role_enabled="false", ping_role_id="not-a-number")
+        )
+        assert m.ping_role_id is None
+
     def test_quotes_stripped_from_options(self):
         m = _validate(_base_form(option1='foo"bar', option2="baz'qux"))
         assert m.options == ["foobar", "bazqux"]

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -314,6 +314,42 @@ class TestPollFormRequestFailures:
         assert "30 days" in str(exc.value)
 
 
+class TestToValidatedDataDict:
+    """``PollFormRequest.to_validated_data_dict`` is the legacy contract
+    consumed by the HTMX endpoints; if a new model field shows up, this
+    method (and these tests) keeps the conversion in one place."""
+
+    def test_keys_match_legacy_contract(self):
+        m = _validate(_base_form())
+        data = m.to_validated_data_dict("user-123")
+        assert set(data) == {
+            "name",
+            "question",
+            "server_id",
+            "channel_id",
+            "options",
+            "open_time",
+            "close_time",
+            "timezone",
+            "anonymous",
+            "multiple_choice",
+            "max_choices",
+            "open_immediately",
+            "ping_role_enabled",
+            "ping_role_id",
+            "ping_role_on_close",
+            "ping_role_on_update",
+            "image_message_text",
+            "creator_id",
+        }
+        assert data["creator_id"] == "user-123"
+        # open_time / close_time use the computed UTC datetimes, not the
+        # raw input strings, so callers can hand them straight to the
+        # scheduler.
+        assert data["open_time"] == m.open_time_utc
+        assert data["close_time"] == m.close_time_utc
+
+
 class TestPollFormDictPassthrough:
     """Behavioral tests for ``poll_form_to_dict``."""
 

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -278,6 +278,33 @@ class TestPollFormRequestFailures:
             _validate(_base_form(timezone=False))
         assert "invalid timezone" in str(exc.value).lower()
 
+    def test_duration_too_short(self):
+        # Fixed summer noon -> safely outside any DST transition.
+        base = pytz.timezone("US/Pacific").localize(datetime(2099, 6, 15, 12, 0))
+        open_dt = base + timedelta(hours=2)
+        close_dt = open_dt + timedelta(seconds=30)
+        with pytest.raises(ValidationError) as exc:
+            _validate(
+                _base_form(
+                    open_time=open_dt.strftime("%Y-%m-%dT%H:%M:%S"),
+                    close_time=close_dt.strftime("%Y-%m-%dT%H:%M:%S"),
+                )
+            )
+        assert "at least 1 minute" in str(exc.value)
+
+    def test_duration_too_long(self):
+        base = pytz.timezone("US/Pacific").localize(datetime(2099, 6, 15, 12, 0))
+        open_dt = base + timedelta(hours=2)
+        close_dt = base + timedelta(days=31)
+        with pytest.raises(ValidationError) as exc:
+            _validate(
+                _base_form(
+                    open_time=open_dt.strftime("%Y-%m-%dT%H:%M"),
+                    close_time=close_dt.strftime("%Y-%m-%dT%H:%M"),
+                )
+            )
+        assert "30 days" in str(exc.value)
+
 
 class TestPollFormDictPassthrough:
     """Behavioral tests for ``poll_form_to_dict``."""
@@ -314,33 +341,6 @@ class TestParsePollFormRequest:
             asyncio.run(parse_poll_form_request(_FakeRequest()))
         assert exc.value.status_code == 422
         assert exc.value.detail and exc.value.detail[0]["field_name"] == "Server"
-
-    def test_duration_too_short(self):
-        # Fixed summer noon -> safely outside any DST transition.
-        base = pytz.timezone("US/Pacific").localize(datetime(2099, 6, 15, 12, 0))
-        open_dt = base + timedelta(hours=2)
-        close_dt = open_dt + timedelta(seconds=30)
-        with pytest.raises(ValidationError) as exc:
-            _validate(
-                _base_form(
-                    open_time=open_dt.strftime("%Y-%m-%dT%H:%M:%S"),
-                    close_time=close_dt.strftime("%Y-%m-%dT%H:%M:%S"),
-                )
-            )
-        assert "at least 1 minute" in str(exc.value)
-
-    def test_duration_too_long(self):
-        base = pytz.timezone("US/Pacific").localize(datetime(2099, 6, 15, 12, 0))
-        open_dt = base + timedelta(hours=2)
-        close_dt = base + timedelta(days=31)
-        with pytest.raises(ValidationError) as exc:
-            _validate(
-                _base_form(
-                    open_time=open_dt.strftime("%Y-%m-%dT%H:%M"),
-                    close_time=close_dt.strftime("%Y-%m-%dT%H:%M"),
-                )
-            )
-        assert "30 days" in str(exc.value)
 
 
 class TestValidationErrorToMessages:

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -1,0 +1,208 @@
+"""Unit tests for ``polly.poll_request_models``."""
+
+from datetime import datetime, timedelta
+
+import pytest
+import pytz
+from pydantic import ValidationError
+
+from polly.poll_request_models import (
+    PollFormRequest,
+    VoteRequest,
+    poll_form_to_dict,
+    validation_error_to_messages,
+)
+
+
+class _FormShim(dict):
+    """Mimic Starlette's ``FormData.get`` interface backed by a plain dict."""
+
+    def get(self, key, default=None):  # type: ignore[override]
+        return super().get(key, default)
+
+
+def _future(hours: int, tz: str = "US/Pacific") -> str:
+    return (
+        (datetime.now(pytz.timezone(tz)) + timedelta(hours=hours))
+        .replace(microsecond=0)
+        .strftime("%Y-%m-%dT%H:%M")
+    )
+
+
+def _base_form(**overrides) -> _FormShim:
+    data = {
+        "name": "Sample Poll",
+        "question": "Which option do you prefer?",
+        "server_id": "12345",
+        "channel_id": "67890",
+        "option1": "alpha",
+        "option2": "beta",
+        "timezone": "US/Pacific",
+        "open_time": _future(2),
+        "close_time": _future(4),
+    }
+    data.update(overrides)
+    return _FormShim(data)
+
+
+def _validate(form: _FormShim) -> PollFormRequest:
+    return PollFormRequest.model_validate(poll_form_to_dict(form))
+
+
+class TestPollFormRequestHappyPath:
+    def test_minimal_valid_payload(self):
+        m = _validate(_base_form())
+        assert m.name == "Sample Poll"
+        assert m.options == ["alpha", "beta"]
+        assert m.timezone == "US/Pacific"
+        assert m.open_time_utc is not None
+        assert m.close_time_utc is not None
+        assert m.close_time_utc > m.open_time_utc
+
+    def test_open_immediately_skips_open_time(self):
+        m = _validate(_base_form(open_immediately="true", open_time=""))
+        assert m.open_immediately is True
+        assert m.open_time_utc is not None
+        assert m.close_time_utc > m.open_time_utc
+
+    def test_max_choices_resolved_for_multiple_choice(self):
+        m = _validate(_base_form(multiple_choice="true", max_choices="2"))
+        assert m.max_choices == 2
+
+    def test_max_choices_dropped_for_single_choice(self):
+        m = _validate(
+            _base_form(multiple_choice="false", max_choices="1")
+        )
+        assert m.max_choices is None
+
+    def test_role_ping_fields_zeroed_when_disabled(self):
+        m = _validate(
+            _base_form(
+                ping_role_enabled="false",
+                ping_role_id="555",
+                ping_role_on_close="true",
+            )
+        )
+        assert m.ping_role_id is None
+        assert m.ping_role_on_close is False
+
+    def test_quotes_stripped_from_options(self):
+        m = _validate(_base_form(option1='foo"bar', option2="baz'qux"))
+        assert m.options == ["foobar", "bazqux"]
+
+    def test_timezone_alias_normalized(self):
+        m = _validate(
+            _base_form(
+                timezone="EDT",
+                open_time=_future(6, "US/Eastern"),
+                close_time=_future(8, "US/Eastern"),
+            )
+        )
+        assert m.timezone == "US/Eastern"
+
+
+class TestPollFormRequestFailures:
+    def test_close_before_open(self):
+        future_open = _future(4)
+        future_close = _future(2)
+        with pytest.raises(ValidationError) as exc:
+            _validate(
+                _base_form(open_time=future_open, close_time=future_close)
+            )
+        assert "after the open time" in str(exc.value)
+
+    def test_open_time_in_past(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(open_time="2020-01-01T00:00"))
+        assert "next full minute" in str(exc.value)
+
+    def test_role_ping_enabled_without_role(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(
+                _base_form(ping_role_enabled="true", ping_role_id="")
+            )
+        assert "select a role" in str(exc.value)
+
+    def test_invalid_close_time_format(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(close_time="not-a-date"))
+        assert "invalid date/time format" in str(exc.value).lower()
+
+    def test_non_numeric_server_id(self):
+        with pytest.raises(ValidationError):
+            _validate(_base_form(server_id="abc"))
+
+    def test_non_numeric_channel_id(self):
+        with pytest.raises(ValidationError):
+            _validate(_base_form(channel_id="xyz"))
+
+    def test_non_numeric_ping_role_id(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(
+                _base_form(ping_role_enabled="true", ping_role_id="foo")
+            )
+        assert "numeric Discord ID" in str(exc.value)
+
+    def test_duplicate_options_rejected(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(option2="alpha"))
+        assert "duplicate" in str(exc.value).lower()
+
+    def test_overlong_option_rejected(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(option2="b" * 101))
+        assert "100 characters" in str(exc.value)
+
+    def test_too_few_options(self):
+        with pytest.raises(ValidationError):
+            _validate(_base_form(option2=""))
+
+    def test_max_choices_exceeds_options(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(
+                _base_form(multiple_choice="true", max_choices="5")
+            )
+        assert "cannot exceed" in str(exc.value)
+
+    def test_max_choices_non_numeric(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(
+                _base_form(multiple_choice="true", max_choices="abc")
+            )
+        assert "valid number" in str(exc.value)
+
+    def test_short_name_rejected(self):
+        with pytest.raises(ValidationError):
+            _validate(_base_form(name="no"))
+
+
+class TestValidationErrorToMessages:
+    def test_translates_value_error_with_field_prefix(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(
+                _base_form(ping_role_enabled="true", ping_role_id="")
+            )
+        msgs = validation_error_to_messages(exc.value)
+        assert msgs and msgs[0]["field_name"] == "Role Selection"
+        assert "select a role" in msgs[0]["message"]
+
+    def test_translates_pattern_failure_with_field_loc(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(server_id="abc"))
+        msgs = validation_error_to_messages(exc.value)
+        assert msgs and msgs[0]["field_name"] == "Server Id"
+
+
+class TestVoteRequest:
+    def test_valid_vote(self):
+        v = VoteRequest.model_validate({"user_id": " 123 ", "option_index": 1})
+        assert v.user_id == "123"
+        assert v.option_index == 1
+
+    def test_negative_option_index_rejected(self):
+        with pytest.raises(ValidationError):
+            VoteRequest.model_validate({"user_id": "1", "option_index": -1})
+
+    def test_empty_user_id_rejected(self):
+        with pytest.raises(ValidationError):
+            VoteRequest.model_validate({"user_id": "", "option_index": 0})

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -292,6 +292,14 @@ class TestPollFormRequestFailures:
             )
         assert "at least 1 minute" in str(exc.value)
 
+    def test_image_message_text_over_2000_chars_rejected(self):
+        # Discord caps message content at 2000 chars; reject up front so
+        # users see a friendly form error instead of an HTTPException at
+        # post time.
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(image_message_text="x" * 2001))
+        assert "image_message_text" in str(exc.value).lower() or "2000" in str(exc.value)
+
     def test_duration_too_long(self):
         base = pytz.timezone("US/Pacific").localize(datetime(2099, 6, 15, 12, 0))
         open_dt = base + timedelta(hours=2)
@@ -463,3 +471,17 @@ class TestVoteRequest:
     def test_empty_user_id_rejected(self):
         with pytest.raises(ValidationError):
             VoteRequest.model_validate({"user_id": "", "option_index": 0})
+
+    def test_non_numeric_user_id_rejected(self):
+        with pytest.raises(ValidationError):
+            VoteRequest.model_validate({"user_id": "abc", "option_index": 0})
+
+    def test_int_user_id_coerced_to_string(self):
+        # Discord snowflakes are ints; accept them and stringify.
+        v = VoteRequest.model_validate({"user_id": 12345, "option_index": 0})
+        assert v.user_id == "12345"
+
+    def test_dict_user_id_rejected(self):
+        # Non-(str|int) types must not be silently turned into "{}" via str(...).
+        with pytest.raises(ValidationError):
+            VoteRequest.model_validate({"user_id": {"id": "1"}, "option_index": 0})

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -342,6 +342,16 @@ class TestValidationErrorToMessages:
         assert not msgs[0]["message"].lower().startswith("options:")
         assert "Add more choices" in msgs[0]["suggestion"]
 
+    def test_informative_option_index_prefix_preserved(self):
+        # "Option 2: must be 100 characters or fewer" carries the index
+        # of the failing option; the wrapper must NOT strip it just
+        # because loc resolves to "options".
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(option2="b" * 101))
+        msgs = validation_error_to_messages(exc.value)
+        assert msgs[0]["field_name"] == "Poll Options"
+        assert msgs[0]["message"].startswith("Option 2:")
+
     def test_poll_duration_prefix_attaches_suggestion(self):
         # Duration error from _validate_time_window has no loc; the
         # synthetic "Poll Duration" prefix should still resolve to the

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -22,11 +22,15 @@ class _FormShim(dict):
 
 
 def _future(hours: int, tz: str = "US/Pacific") -> str:
-    return (
-        (datetime.now(pytz.timezone(tz)) + timedelta(hours=hours))
-        .replace(microsecond=0)
-        .strftime("%Y-%m-%dT%H:%M")
-    )
+    """Return a fixed summer-noon datetime offset by ``hours`` in ``tz``.
+
+    Using a fixed far-future summer date (rather than ``datetime.now() +
+    timedelta``) keeps tests deterministic and avoids landing on DST
+    gap/overlap wall-clock times that ``tz.localize(..., is_dst=None)``
+    would reject as ambiguous or non-existent.
+    """
+    base = pytz.timezone(tz).localize(datetime(2099, 6, 15, 12, 0))
+    return (base + timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M")
 
 
 def _base_form(**overrides) -> _FormShim:
@@ -60,7 +64,17 @@ class TestPollFormRequestHappyPath:
         assert m.close_time_utc > m.open_time_utc
 
     def test_open_immediately_skips_open_time(self):
-        m = _validate(_base_form(open_immediately="true", open_time=""))
+        # When opening immediately, close_time must be relative to *now*,
+        # not the fixed-future _future() helper, since the duration is
+        # measured from the current moment.
+        close_dt = datetime.now(pytz.timezone("US/Pacific")) + timedelta(hours=2)
+        m = _validate(
+            _base_form(
+                open_immediately="true",
+                open_time="",
+                close_time=close_dt.replace(microsecond=0).strftime("%Y-%m-%dT%H:%M"),
+            )
+        )
         assert m.open_immediately is True
         assert m.open_time_utc is not None
         assert m.close_time_utc > m.open_time_utc
@@ -222,12 +236,9 @@ class TestPollFormRequestFailures:
         assert "invalid timezone" in str(exc.value).lower()
 
     def test_duration_too_short(self):
-        tz = pytz.timezone("US/Pacific")
-        open_dt = (
-            (datetime.now(tz) + timedelta(hours=2))
-            .replace(second=0, microsecond=0)
-        )
-        # 30 seconds after open -> duration below the 1-minute floor.
+        # Fixed summer noon -> safely outside any DST transition.
+        base = pytz.timezone("US/Pacific").localize(datetime(2099, 6, 15, 12, 0))
+        open_dt = base + timedelta(hours=2)
         close_dt = open_dt + timedelta(seconds=30)
         with pytest.raises(ValidationError) as exc:
             _validate(
@@ -239,15 +250,16 @@ class TestPollFormRequestFailures:
         assert "at least 1 minute" in str(exc.value)
 
     def test_duration_too_long(self):
-        tz = pytz.timezone("US/Pacific")
-        open_t = _future(2)
-        close_t = (
-            (datetime.now(tz) + timedelta(days=31))
-            .replace(microsecond=0)
-            .strftime("%Y-%m-%dT%H:%M")
-        )
+        base = pytz.timezone("US/Pacific").localize(datetime(2099, 6, 15, 12, 0))
+        open_dt = base + timedelta(hours=2)
+        close_dt = base + timedelta(days=31)
         with pytest.raises(ValidationError) as exc:
-            _validate(_base_form(open_time=open_t, close_time=close_t))
+            _validate(
+                _base_form(
+                    open_time=open_dt.strftime("%Y-%m-%dT%H:%M"),
+                    close_time=close_dt.strftime("%Y-%m-%dT%H:%M"),
+                )
+            )
         assert "30 days" in str(exc.value)
 
 
@@ -275,6 +287,15 @@ class TestValidationErrorToMessages:
         msgs = validation_error_to_messages(exc.value)
         assert msgs[0]["field_name"] == "Channel"
         assert msgs[0]["message"] == "Please select a Discord channel"
+
+    def test_missing_server_id_uses_friendly_copy(self):
+        # Empty string mimics an unselected dropdown -> string_too_short
+        # under the digits-only pattern; should still surface friendly copy.
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(server_id=""))
+        msgs = validation_error_to_messages(exc.value)
+        assert msgs[0]["field_name"] == "Server"
+        assert msgs[0]["message"] == "Please select a Discord server"
 
     def test_model_level_value_error_keeps_suggestion(self):
         # Role-Selection error originates from a model_validator and has

--- a/tests/test_poll_request_models.py
+++ b/tests/test_poll_request_models.py
@@ -90,6 +90,14 @@ class TestPollFormRequestHappyPath:
         m = _validate(_base_form(option1='foo"bar', option2="baz'qux"))
         assert m.options == ["foobar", "bazqux"]
 
+    def test_internal_utc_fields_excluded_from_dump(self):
+        m = _validate(_base_form())
+        dumped = m.model_dump()
+        assert "open_time_utc" not in dumped
+        assert "close_time_utc" not in dumped
+        # but the parsed datetimes are still accessible on the instance.
+        assert m.open_time_utc is not None
+
     def test_timezone_alias_normalized(self):
         m = _validate(
             _base_form(
@@ -190,7 +198,15 @@ class TestValidationErrorToMessages:
         with pytest.raises(ValidationError) as exc:
             _validate(_base_form(server_id="abc"))
         msgs = validation_error_to_messages(exc.value)
-        assert msgs and msgs[0]["field_name"] == "Server Id"
+        assert msgs and msgs[0]["field_name"] == "Server"
+        assert "post this poll" in msgs[0]["suggestion"]
+
+    def test_min_length_failure_uses_friendly_label(self):
+        with pytest.raises(ValidationError) as exc:
+            _validate(_base_form(name="no"))
+        msgs = validation_error_to_messages(exc.value)
+        assert msgs[0]["field_name"] == "Poll Name"
+        assert "descriptive" in msgs[0]["suggestion"]
 
 
 class TestVoteRequest:


### PR DESCRIPTION
## Summary
- New `polly/poll_request_models.py` defines `PollFormRequest` (re-exported as `PollCreateRequest`/`PollUpdateRequest`) and `VoteRequest`, plus a `parse_poll_form_request` FastAPI dependency so callers can swap `form_data.get(...)` for `Depends(parse_poll_form_request)` + `model_validate`.
- `validate_poll_form_data` in `htmx_endpoints.py` is now a thin wrapper around `PollFormRequest.model_validate`, replacing ~300 lines of hand-rolled validation/branching with one source of truth.
- `VoteValidator.validate_vote_data` now routes `user_id`/`option_index` through `VoteRequest`, so coercion and bounds bugs surface in one place.

## Why
Centralizing form validation under Pydantic v2 eliminates a class of validation bugs (boolean coercion of `"true"` strings, missing-field handling, time-window edge cases, role-ping field interdependence) that previously had to be re-implemented at each call site.

## Test plan
- [x] `pytest tests/test_validators.py::TestVoteValidator` — 7/7 pass
- [x] `pytest tests/test_validators.py` — 46/47 pass; the single failure (`test_validate_poll_options_sanitization`) reproduces on `main` and is unrelated.
- [x] Smoke-tested `PollFormRequest` and the `validate_poll_form_data` wrapper for valid input, missing required fields, role-ping enabled with no role, scheduled past `open_time`, and `close_time <= open_time`.
- [ ] Manual verification of the create/edit form in the browser (not possible in this environment).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RP49r8v8qkBwxmUdkgaNPQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized poll form validation with standardized parsed outputs (normalized timezone, UTC schedule times, cleaned options, and resolved max-choices).
* **Bug Fixes**
  * Clearer, field-specific error messages and stricter checks for options, names, scheduling, and role-ping inputs.
  * Vote input validation tightened to reject invalid IDs and invalid option selections.
* **Tests**
  * Added end-to-end tests for form parsing, scheduling rules, option cleaning, role-ping behavior, and vote validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->