### PR TITLE
Fix manual poll close not notifying users (#26)

### DIFF
--- a/polly/services/poll/poll_closure_service.py
+++ b/polly/services/poll/poll_closure_service.py
@@ -192,11 +192,28 @@ class PollClosureService:
                                         role_id_int = int(role_id)
                                         guild = getattr(channel, "guild", None)
                                         role_obj = guild.get_role(role_id_int) if guild else None
-                                        bot_member = guild.me if guild else None
-                                        can_mention_everyone = bool(
-                                            bot_member
-                                            and channel.permissions_for(bot_member).mention_everyone
-                                        )
+
+                                        # Resolve the bot's guild Member to check
+                                        # mention_everyone. `guild.me` is normally
+                                        # populated regardless of the members intent,
+                                        # but fall back to `get_member(bot.user.id)`
+                                        # for setups where it isn't cached.
+                                        bot_member = None
+                                        if guild:
+                                            bot_member = guild.me
+                                            if bot_member is None and bot_instance.user is not None:
+                                                bot_member = guild.get_member(bot_instance.user.id)
+
+                                        if bot_member is not None:
+                                            can_mention_everyone = bool(
+                                                channel.permissions_for(bot_member).mention_everyone
+                                            )
+                                        else:
+                                            # Permissions are unknown — be optimistic
+                                            # and let the discord.Forbidden fallback
+                                            # handle the case where the bot really
+                                            # can't ping the role.
+                                            can_mention_everyone = True
 
                                         if role_obj is None:
                                             logger.warning(

--- a/polly/services/poll/poll_closure_service.py
+++ b/polly/services/poll/poll_closure_service.py
@@ -259,10 +259,13 @@ class PollClosureService:
                                                     f"⚠️ UNIFIED CLOSE {poll_id} - Embed fallback forbidden, retrying as plain text: {embed_forbidden}"
                                                 )
                                             except Exception as fallback_error:
+                                                # Log the failure but still drop through
+                                                # to the plain-text fallback so a transient
+                                                # HTTP/embed glitch doesn't leave users
+                                                # with no closure notification.
                                                 logger.error(
-                                                    f"❌ UNIFIED CLOSE {poll_id} - Fallback notification also failed: {fallback_error}"
+                                                    f"❌ UNIFIED CLOSE {poll_id} - Embed fallback notification failed, retrying as plain text: {fallback_error}"
                                                 )
-                                                embed_fallback_handled = True
 
                                         if not embed_fallback_handled:
                                             # Plain-text fallback: bot likely lacks

--- a/polly/services/poll/poll_closure_service.py
+++ b/polly/services/poll/poll_closure_service.py
@@ -161,7 +161,7 @@ class PollClosureService:
                     ping_role_id = TypeSafeColumn.get_string(fresh_poll, "ping_role_id")
                     ping_role_on_close = TypeSafeColumn.get_bool(fresh_poll, "ping_role_on_close", False)
                     ping_role_name = TypeSafeColumn.get_string(fresh_poll, "ping_role_name", "Unknown Role")
-                    
+
                     if ping_role_enabled and ping_role_id and ping_role_on_close:
                         try:
                             poll_channel_id = TypeSafeColumn.get_string(fresh_poll, "channel_id")
@@ -169,41 +169,64 @@ class PollClosureService:
                                 channel = bot_instance.get_channel(int(poll_channel_id))
                                 if channel and isinstance(channel, discord.TextChannel):
                                     poll_name = TypeSafeColumn.get_string(fresh_poll, "name", "Unknown Poll")
-                                    
-                                    # Prepare role ping message with comprehensive error handling
-                                    message_content = f"📊 **Poll '{poll_name}' has ended!**"
-                                    role_ping_attempted = False
-                                    
                                     role_id = str(ping_role_id)
-                                    message_content = f"<@&{role_id}> {message_content}"
-                                    role_ping_attempted = True
+
+                                    # Build the closing notification: role mention + final
+                                    # results embed in a single message, matching the
+                                    # open path's atomic role-ping-with-content style.
+                                    fallback_content = f"📊 **Poll '{poll_name}' has ended!**"
+                                    message_content = f"<@&{role_id}> {fallback_content}"
+
+                                    # Explicitly allow the configured role mention so the
+                                    # ping isn't suppressed by the client/bot default
+                                    # AllowedMentions policy. Discord still enforces role
+                                    # mentionability / Mention Everyone permission, but
+                                    # without this the mention can be dropped silently
+                                    # before it reaches Discord.
+                                    allowed_mentions = discord.AllowedMentions(
+                                        everyone=False,
+                                        users=False,
+                                        roles=[discord.Object(id=int(role_id))],
+                                    )
+
+                                    try:
+                                        from polly.discord_utils import create_poll_results_embed
+                                        results_embed = await create_poll_results_embed(fresh_poll)
+                                    except Exception as embed_error:
+                                        logger.error(
+                                            f"❌ UNIFIED CLOSE {poll_id} - Failed to build results embed for closure notification: {embed_error}"
+                                        )
+                                        results_embed = None
+
                                     logger.info(
                                         f"🔔 UNIFIED CLOSE {poll_id} - Will ping role {ping_role_name} ({role_id}) for poll closure"
                                     )
-                                    
+
                                     # Send role ping message with graceful error handling
                                     try:
-                                        await channel.send(content=message_content)
+                                        await channel.send(
+                                            content=message_content,
+                                            embed=results_embed,
+                                            allowed_mentions=allowed_mentions,
+                                        )
                                         logger.info(f"✅ UNIFIED CLOSE {poll_id} - Sent role ping notification")
                                     except discord.Forbidden as role_error:
-                                        if role_ping_attempted:
-                                            # Role ping failed due to permissions, try without role ping
-                                            logger.warning(
-                                                f"⚠️ UNIFIED CLOSE {poll_id} - Role ping failed due to permissions, posting without role ping: {role_error}"
+                                        # Role ping failed due to permissions, try without role ping
+                                        logger.warning(
+                                            f"⚠️ UNIFIED CLOSE {poll_id} - Role ping failed due to permissions, posting without role ping: {role_error}"
+                                        )
+                                        try:
+                                            await channel.send(
+                                                content=fallback_content,
+                                                embed=results_embed,
                                             )
-                                            try:
-                                                fallback_content = f"📊 **Poll '{poll_name}' has ended!**"
-                                                await channel.send(content=fallback_content)
-                                                logger.info(
-                                                    f"✅ UNIFIED CLOSE {poll_id} - Sent fallback notification without role ping"
-                                                )
-                                            except Exception as fallback_error:
-                                                logger.error(
-                                                    f"❌ UNIFIED CLOSE {poll_id} - Fallback notification also failed: {fallback_error}"
-                                                )
-                                        else:
-                                            # Not a role ping issue, re-raise the error
-                                            raise role_error
+                                            logger.info(
+                                                f"✅ UNIFIED CLOSE {poll_id} - Sent fallback notification without role ping"
+                                            )
+                                        except Exception as fallback_error:
+                                            logger.error(
+                                                f"❌ UNIFIED CLOSE {poll_id} - Fallback notification also failed: {fallback_error}"
+                                            )
                                     except Exception as send_error:
                                         logger.error(f"❌ UNIFIED CLOSE {poll_id} - Error sending role ping notification: {send_error}")
                                 else:

--- a/polly/services/poll/poll_closure_service.py
+++ b/polly/services/poll/poll_closure_service.py
@@ -227,10 +227,17 @@ class PollClosureService:
                                         logger.warning(
                                             f"⚠️ UNIFIED CLOSE {poll_id} - Role ping failed due to permissions, posting without role ping: {role_error}"
                                         )
+                                        # `fallback_content` interpolates the poll name,
+                                        # which is user-controlled, so the fallback sends
+                                        # disable all mentions to prevent an "@everyone" or
+                                        # arbitrary role/user mention smuggled into the poll
+                                        # name from being pinged.
+                                        no_mentions = discord.AllowedMentions.none()
                                         try:
                                             await channel.send(
                                                 content=fallback_content,
                                                 embed=results_embed,
+                                                allowed_mentions=no_mentions,
                                             )
                                             logger.info(
                                                 f"✅ UNIFIED CLOSE {poll_id} - Sent fallback notification without role ping"
@@ -243,7 +250,10 @@ class PollClosureService:
                                                 f"⚠️ UNIFIED CLOSE {poll_id} - Embed fallback forbidden, retrying as plain text: {embed_forbidden}"
                                             )
                                             try:
-                                                await channel.send(content=fallback_content)
+                                                await channel.send(
+                                                    content=fallback_content,
+                                                    allowed_mentions=no_mentions,
+                                                )
                                                 logger.info(
                                                     f"✅ UNIFIED CLOSE {poll_id} - Sent plain-text fallback notification"
                                                 )

--- a/polly/services/poll/poll_closure_service.py
+++ b/polly/services/poll/poll_closure_service.py
@@ -178,27 +178,46 @@ class PollClosureService:
 
                                     # Explicitly allow the configured role mention so the
                                     # ping isn't suppressed by the client/bot default
-                                    # AllowedMentions policy. Discord still enforces role
-                                    # mentionability / Mention Everyone permission, but
-                                    # without this the mention can be dropped silently
-                                    # before it reaches Discord. Guard the int() conversion
-                                    # so a tampered DB value falls back to a no-mention post
-                                    # rather than skipping the notification entirely.
+                                    # AllowedMentions policy. Pre-resolve the role on the
+                                    # guild and only attempt the mention if the role still
+                                    # exists and Discord would actually deliver the ping
+                                    # (role mentionable, or bot has Mention Everyone).
+                                    # That way the "Will ping role …" log reflects reality
+                                    # rather than always firing for a parseable id.
+                                    no_mentions = discord.AllowedMentions.none()
+                                    role_mention_attempted = False
+                                    allowed_mentions = no_mentions
+                                    message_content = fallback_content
                                     try:
-                                        allowed_mentions = discord.AllowedMentions(
-                                            everyone=False,
-                                            users=False,
-                                            roles=[discord.Object(id=int(role_id))],
+                                        role_id_int = int(role_id)
+                                        guild = getattr(channel, "guild", None)
+                                        role_obj = guild.get_role(role_id_int) if guild else None
+                                        bot_member = guild.me if guild else None
+                                        can_mention_everyone = bool(
+                                            bot_member
+                                            and channel.permissions_for(bot_member).mention_everyone
                                         )
-                                        message_content = f"<@&{role_id}> {fallback_content}"
-                                        role_mention_attempted = True
+
+                                        if role_obj is None:
+                                            logger.warning(
+                                                f"⚠️ UNIFIED CLOSE {poll_id} - Configured role {role_id} not found in guild; posting without role ping"
+                                            )
+                                        elif not role_obj.mentionable and not can_mention_everyone:
+                                            logger.warning(
+                                                f"⚠️ UNIFIED CLOSE {poll_id} - Role {ping_role_name} ({role_id}) is not mentionable and bot lacks Mention Everyone; posting without role ping"
+                                            )
+                                        else:
+                                            allowed_mentions = discord.AllowedMentions(
+                                                everyone=False,
+                                                users=False,
+                                                roles=[role_obj],
+                                            )
+                                            message_content = f"<@&{role_id}> {fallback_content}"
+                                            role_mention_attempted = True
                                     except (ValueError, TypeError):
                                         logger.warning(
                                             f"⚠️ UNIFIED CLOSE {poll_id} - Invalid role ID format: {role_id!r}; posting without role ping"
                                         )
-                                        allowed_mentions = discord.AllowedMentions.none()
-                                        message_content = fallback_content
-                                        role_mention_attempted = False
 
                                     try:
                                         from polly.discord_utils import create_poll_results_embed
@@ -214,12 +233,11 @@ class PollClosureService:
                                             f"🔔 UNIFIED CLOSE {poll_id} - Will ping role {ping_role_name} ({role_id}) for poll closure"
                                         )
 
-                                    # `fallback_content` interpolates the
-                                    # user-controlled poll name, so the fallback send
-                                    # disables all mentions to prevent an "@everyone" or
-                                    # arbitrary role/user mention smuggled into the
-                                    # poll name from being pinged.
-                                    no_mentions = discord.AllowedMentions.none()
+                                    # `fallback_content` interpolates the user-controlled
+                                    # poll name, so every fallback send reuses the
+                                    # `no_mentions` policy declared above to prevent an
+                                    # "@everyone" or arbitrary role/user mention smuggled
+                                    # into the poll name from being pinged.
 
                                     # Send the closure notification with graceful
                                     # error handling. discord.Forbidden can mean the

--- a/polly/services/poll/poll_closure_service.py
+++ b/polly/services/poll/poll_closure_service.py
@@ -214,41 +214,61 @@ class PollClosureService:
                                             f"🔔 UNIFIED CLOSE {poll_id} - Will ping role {ping_role_name} ({role_id}) for poll closure"
                                         )
 
-                                    # Send role ping message with graceful error handling
+                                    # `fallback_content` interpolates the
+                                    # user-controlled poll name, so the fallback send
+                                    # disables all mentions to prevent an "@everyone" or
+                                    # arbitrary role/user mention smuggled into the
+                                    # poll name from being pinged.
+                                    no_mentions = discord.AllowedMentions.none()
+
+                                    # Send the closure notification with graceful
+                                    # error handling. discord.Forbidden can mean the
+                                    # bot can't send at all, can't ping the role, or
+                                    # lacks Embed Links — try progressively cheaper
+                                    # variants until one works.
                                     try:
                                         await channel.send(
                                             content=message_content,
                                             embed=results_embed,
                                             allowed_mentions=allowed_mentions,
                                         )
-                                        logger.info(f"✅ UNIFIED CLOSE {poll_id} - Sent role ping notification")
-                                    except discord.Forbidden as role_error:
-                                        # Role ping failed due to permissions, try without role ping
+                                        logger.info(f"✅ UNIFIED CLOSE {poll_id} - Sent closure notification")
+                                    except discord.Forbidden as send_forbidden:
                                         logger.warning(
-                                            f"⚠️ UNIFIED CLOSE {poll_id} - Role ping failed due to permissions, posting without role ping: {role_error}"
+                                            f"⚠️ UNIFIED CLOSE {poll_id} - Closure send forbidden, attempting fallbacks: {send_forbidden}"
                                         )
-                                        # `fallback_content` interpolates the poll name,
-                                        # which is user-controlled, so the fallback sends
-                                        # disable all mentions to prevent an "@everyone" or
-                                        # arbitrary role/user mention smuggled into the poll
-                                        # name from being pinged.
-                                        no_mentions = discord.AllowedMentions.none()
-                                        try:
-                                            await channel.send(
-                                                content=fallback_content,
-                                                embed=results_embed,
-                                                allowed_mentions=no_mentions,
-                                            )
-                                            logger.info(
-                                                f"✅ UNIFIED CLOSE {poll_id} - Sent fallback notification without role ping"
-                                            )
-                                        except discord.Forbidden as embed_forbidden:
-                                            # Bot likely lacks Embed Links; fall back to a
-                                            # plain-text notification so users still get a
-                                            # signal that the poll closed.
-                                            logger.warning(
-                                                f"⚠️ UNIFIED CLOSE {poll_id} - Embed fallback forbidden, retrying as plain text: {embed_forbidden}"
-                                            )
+
+                                        embed_fallback_handled = False
+                                        # Only retry without the role mention if we
+                                        # actually attempted one — otherwise the
+                                        # primary send is already the no-mention
+                                        # variant and a retry would be identical.
+                                        if role_mention_attempted:
+                                            try:
+                                                await channel.send(
+                                                    content=fallback_content,
+                                                    embed=results_embed,
+                                                    allowed_mentions=no_mentions,
+                                                )
+                                                logger.info(
+                                                    f"✅ UNIFIED CLOSE {poll_id} - Sent fallback notification without role ping"
+                                                )
+                                                embed_fallback_handled = True
+                                            except discord.Forbidden as embed_forbidden:
+                                                logger.warning(
+                                                    f"⚠️ UNIFIED CLOSE {poll_id} - Embed fallback forbidden, retrying as plain text: {embed_forbidden}"
+                                                )
+                                            except Exception as fallback_error:
+                                                logger.error(
+                                                    f"❌ UNIFIED CLOSE {poll_id} - Fallback notification also failed: {fallback_error}"
+                                                )
+                                                embed_fallback_handled = True
+
+                                        if not embed_fallback_handled:
+                                            # Plain-text fallback: bot likely lacks
+                                            # Embed Links (or never had a mention to
+                                            # drop). Send without an embed so users
+                                            # still see that the poll closed.
                                             try:
                                                 await channel.send(
                                                     content=fallback_content,
@@ -261,12 +281,8 @@ class PollClosureService:
                                                 logger.error(
                                                     f"❌ UNIFIED CLOSE {poll_id} - Plain-text fallback also failed: {plain_error}"
                                                 )
-                                        except Exception as fallback_error:
-                                            logger.error(
-                                                f"❌ UNIFIED CLOSE {poll_id} - Fallback notification also failed: {fallback_error}"
-                                            )
                                     except Exception as send_error:
-                                        logger.error(f"❌ UNIFIED CLOSE {poll_id} - Error sending role ping notification: {send_error}")
+                                        logger.error(f"❌ UNIFIED CLOSE {poll_id} - Error sending closure notification: {send_error}")
                                 else:
                                     logger.warning(f"⚠️ UNIFIED CLOSE {poll_id} - Could not find or access channel {poll_channel_id}")
                             else:

--- a/polly/services/poll/poll_closure_service.py
+++ b/polly/services/poll/poll_closure_service.py
@@ -175,19 +175,30 @@ class PollClosureService:
                                     # results embed in a single message, matching the
                                     # open path's atomic role-ping-with-content style.
                                     fallback_content = f"📊 **Poll '{poll_name}' has ended!**"
-                                    message_content = f"<@&{role_id}> {fallback_content}"
 
                                     # Explicitly allow the configured role mention so the
                                     # ping isn't suppressed by the client/bot default
                                     # AllowedMentions policy. Discord still enforces role
                                     # mentionability / Mention Everyone permission, but
                                     # without this the mention can be dropped silently
-                                    # before it reaches Discord.
-                                    allowed_mentions = discord.AllowedMentions(
-                                        everyone=False,
-                                        users=False,
-                                        roles=[discord.Object(id=int(role_id))],
-                                    )
+                                    # before it reaches Discord. Guard the int() conversion
+                                    # so a tampered DB value falls back to a no-mention post
+                                    # rather than skipping the notification entirely.
+                                    try:
+                                        allowed_mentions = discord.AllowedMentions(
+                                            everyone=False,
+                                            users=False,
+                                            roles=[discord.Object(id=int(role_id))],
+                                        )
+                                        message_content = f"<@&{role_id}> {fallback_content}"
+                                        role_mention_attempted = True
+                                    except (ValueError, TypeError):
+                                        logger.warning(
+                                            f"⚠️ UNIFIED CLOSE {poll_id} - Invalid role ID format: {role_id!r}; posting without role ping"
+                                        )
+                                        allowed_mentions = discord.AllowedMentions.none()
+                                        message_content = fallback_content
+                                        role_mention_attempted = False
 
                                     try:
                                         from polly.discord_utils import create_poll_results_embed
@@ -198,9 +209,10 @@ class PollClosureService:
                                         )
                                         results_embed = None
 
-                                    logger.info(
-                                        f"🔔 UNIFIED CLOSE {poll_id} - Will ping role {ping_role_name} ({role_id}) for poll closure"
-                                    )
+                                    if role_mention_attempted:
+                                        logger.info(
+                                            f"🔔 UNIFIED CLOSE {poll_id} - Will ping role {ping_role_name} ({role_id}) for poll closure"
+                                        )
 
                                     # Send role ping message with graceful error handling
                                     try:
@@ -223,6 +235,22 @@ class PollClosureService:
                                             logger.info(
                                                 f"✅ UNIFIED CLOSE {poll_id} - Sent fallback notification without role ping"
                                             )
+                                        except discord.Forbidden as embed_forbidden:
+                                            # Bot likely lacks Embed Links; fall back to a
+                                            # plain-text notification so users still get a
+                                            # signal that the poll closed.
+                                            logger.warning(
+                                                f"⚠️ UNIFIED CLOSE {poll_id} - Embed fallback forbidden, retrying as plain text: {embed_forbidden}"
+                                            )
+                                            try:
+                                                await channel.send(content=fallback_content)
+                                                logger.info(
+                                                    f"✅ UNIFIED CLOSE {poll_id} - Sent plain-text fallback notification"
+                                                )
+                                            except Exception as plain_error:
+                                                logger.error(
+                                                    f"❌ UNIFIED CLOSE {poll_id} - Plain-text fallback also failed: {plain_error}"
+                                                )
                                         except Exception as fallback_error:
                                             logger.error(
                                                 f"❌ UNIFIED CLOSE {poll_id} - Fallback notification also failed: {fallback_error}"


### PR DESCRIPTION
Closes #26.

## Summary

Manual poll closure with **"When poll closes"** (`ping_role_on_close`) checked sent the role mention as a content-only message after the embed update + reaction clear. Two problems:

- **No `allowed_mentions` set.** The default policy can silently drop role mentions before they reach Discord, so the configured role would never get pinged.
- **No results embed bundled with the mention.** Even when the ping did fire, members of the role saw a bare "Poll has ended" line with no results — inconsistent with the open path, which bundles the role mention with the poll embed in a single `channel.send`.

## Changes

`polly/services/poll/poll_closure_service.py` — `close_poll_unified`:

- Build the closure notification with the final results embed (`create_poll_results_embed`) **and** the role mention in the same `channel.send`, mirroring `post_poll_to_channel`'s atomic open-time pattern.
- Pass `discord.AllowedMentions(everyone=False, users=False, roles=[discord.Object(id=role_id)])` so the configured role is explicitly whitelisted and the mention isn't dropped before reaching Discord.
- Keep the existing `discord.Forbidden` fallback (post the embed without the role mention) for cases where the bot lacks Mention Everyone / Manage Roles and the role isn't otherwise mentionable.

## Test plan

- [ ] Create a poll with role ping enabled and **When poll closes** checked.
- [ ] Manually close the poll from the dashboard card → verify the channel receives a single message that pings the role and includes the results embed.
- [ ] Manually close from the poll details page → same expectation.
- [ ] Scheduled close path (also goes through `close_poll_unified`) still works.
- [ ] Closing with **When poll closes** unchecked posts no role-ping message (existing behavior).
- [ ] If the bot lacks permission to ping the role, the embed is still posted via the `discord.Forbidden` fallback and the closure completes successfully.


---
_Generated by [Claude Code](https://claude.ai/code/session_015KUDVw9BjPimydGBZt4DvP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Poll closure now always sends a final-results notification, attempting to include the results embed and the configured role mention when permitted.

* **Bug Fixes**
  * Improved graceful fallback chain: on permission or embed failures the system retries without the mention, then falls back to plain text so a closure message is always delivered.
  * Invalid role IDs no longer produce mention markup.

* **Security**
  * Mentions restricted to the configured role; global and user mentions disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->